### PR TITLE
ALBW-Style Meter

### DIFF
--- a/mm/2s2h/BenGui/BenMenuBar.cpp
+++ b/mm/2s2h/BenGui/BenMenuBar.cpp
@@ -535,6 +535,8 @@ void DrawEnhancementsMenu() {
                                         { .tooltip = "Requires scene reload to take effect." })) {
                 UpdatePlayAsKafeiSkeletons();
             }
+            UIWidgets::CVarCheckbox("ALBW-Style Meter", "gModes.ALBWMeter",
+                                        { .tooltip = "Makes several items utilize the meter." });
             ImGui::EndMenu();
         }
         if (UIWidgets::BeginMenu("Player Movement")) {

--- a/mm/2s2h/DeveloperTools/DeveloperTools.cpp
+++ b/mm/2s2h/DeveloperTools/DeveloperTools.cpp
@@ -56,7 +56,8 @@ void RegisterDebugSaveCreate() {
 
                 gSaveContext.save.saveInfo.inventory.defenseHearts = 20;
                 gSaveContext.save.saveInfo.regionsVisited = (1 << REGION_MAX) - 1;
-                gSaveContext.magicCapacity = MAGIC_DOUBLE_METER;
+                if (CVarGetInteger("gModes.ALBWMeter", 0)) gSaveContext.magicCapacity = 0x30;
+                else gSaveContext.magicCapacity = MAGIC_DOUBLE_METER;
 
                 Inventory_ChangeUpgrade(UPG_WALLET, 2);
                 Inventory_ChangeUpgrade(UPG_BOMB_BAG, 3);

--- a/mm/2s2h/DeveloperTools/SaveEditor.cpp
+++ b/mm/2s2h/DeveloperTools/SaveEditor.cpp
@@ -266,7 +266,8 @@ void DrawGeneralTab() {
 
     ImGui::BeginGroup();
     if (UIWidgets::Button("Max Magic", { .color = UIWidgets::Colors::DarkGreen, .size = UIWidgets::Sizes::Inline })) {
-        gSaveContext.magicCapacity = gSaveContext.save.saveInfo.playerData.magic = MAGIC_DOUBLE_METER;
+        if (CVarGetInteger("gModes.ALBWMeter", 0)) gSaveContext.magicCapacity = gSaveContext.save.saveInfo.playerData.magic = 0x30;
+        else gSaveContext.magicCapacity = gSaveContext.save.saveInfo.playerData.magic = MAGIC_DOUBLE_METER;
         gSaveContext.save.saveInfo.playerData.magicLevel = 2;
         gSaveContext.save.saveInfo.playerData.isMagicAcquired = true;
         gSaveContext.save.saveInfo.playerData.isDoubleMagicAcquired = true;
@@ -284,7 +285,8 @@ void DrawGeneralTab() {
     if (ImGui::SliderScalar("##magicLevelSlider", ImGuiDataType_S8, &gSaveContext.save.saveInfo.playerData.magicLevel,
                             &S8_ZERO, &MAGIC_LEVEL_MAX,
                             MAGIC_LEVEL_NAMES[gSaveContext.save.saveInfo.playerData.magicLevel])) {
-        gSaveContext.magicCapacity = gSaveContext.save.saveInfo.playerData.magicLevel * MAGIC_NORMAL_METER;
+        if (CVarGetInteger("gModes.ALBWMeter", 0)) gSaveContext.magicCapacity = gSaveContext.save.saveInfo.playerData.magicLevel * (0.5 * 0x30);
+        else gSaveContext.magicCapacity = gSaveContext.save.saveInfo.playerData.magicLevel * MAGIC_NORMAL_METER;
         gSaveContext.save.saveInfo.playerData.magic =
             MIN(gSaveContext.save.saveInfo.playerData.magic, gSaveContext.magicCapacity);
         switch (gSaveContext.save.saveInfo.playerData.magicLevel) {

--- a/mm/2s2h/Enhancements/Enhancements.cpp
+++ b/mm/2s2h/Enhancements/Enhancements.cpp
@@ -42,6 +42,7 @@ void InitEnhancements() {
 
     // Modes
     RegisterPlayAsKafei();
+    RegisterALBWMeter();
 
     // Player Movement
     RegisterClimbSpeed();

--- a/mm/2s2h/Enhancements/GameInteractor/GameInteractor.cpp
+++ b/mm/2s2h/Enhancements/GameInteractor/GameInteractor.cpp
@@ -183,6 +183,16 @@ void GameInteractor_ExecuteOnItemGive(u8 item) {
     GameInteractor::Instance->ExecuteHooksForFilter<GameInteractor::OnItemGive>(item);
 }
 
+void GameInteractor_ExecuteOnChangeAmmoHooks(s16 item, s16 ammoChange) {
+    GameInteractor::Instance->ExecuteHooks<GameInteractor::OnChangeAmmo>(item, ammoChange);
+    //GameInteractor::Instance->ExecuteHooksForID<GameInteractor::OnChangeAmmo>(item, ammoChange, ammoChange);
+    GameInteractor::Instance->ExecuteHooksForFilter<GameInteractor::OnChangeAmmo>(item, ammoChange);
+}
+
+void GameInteractor_ExecuteOnPlayerUpdate() {
+    GameInteractor::Instance->ExecuteHooks<GameInteractor::OnPlayerUpdate>();
+}
+
 bool GameInteractor_Should(GIVanillaBehavior flag, bool result, void* opt) {
     GameInteractor::Instance->ExecuteHooks<GameInteractor::ShouldVanillaBehavior>(flag, &result, opt);
     GameInteractor::Instance->ExecuteHooksForID<GameInteractor::ShouldVanillaBehavior>(flag, flag, &result, opt);

--- a/mm/2s2h/Enhancements/GameInteractor/GameInteractor.h
+++ b/mm/2s2h/Enhancements/GameInteractor/GameInteractor.h
@@ -281,6 +281,8 @@ class GameInteractor {
     DEFINE_HOOK(OnItemGive, (u8 item));
 
     DEFINE_HOOK(ShouldVanillaBehavior, (GIVanillaBehavior flag, bool* should, void* optionalArg));
+    DEFINE_HOOK(OnChangeAmmo, (s16 item, s16 ammoChange));
+    DEFINE_HOOK(OnPlayerUpdate, ());
 };
 
 extern "C" {
@@ -317,6 +319,9 @@ void GameInteractor_ExecuteOnCameraChangeSettingsFlags(Camera* camera);
 void GameInteractor_ExecuteOnPassPlayerInputs(Input* input);
 
 void GameInteractor_ExecuteOnOpenText(u16 textId);
+
+void GameInteractor_ExecuteOnChangeAmmoHooks(s16 item, s16 ammoChange);
+void GameInteractor_ExecuteOnPlayerUpdate();
 
 bool GameInteractor_ShouldItemGive(u8 item);
 void GameInteractor_ExecuteOnItemGive(u8 item);

--- a/mm/2s2h/Enhancements/Graphics/PlayAsKafei.cpp
+++ b/mm/2s2h/Enhancements/Graphics/PlayAsKafei.cpp
@@ -4,8 +4,11 @@
 
 extern "C" {
 #include "z64.h"
+#include "z64save.h"
 #include "functions.h"
 extern PlayState* gPlayState;
+extern SaveContext gSaveContext;
+extern u8 gItemSlots[77];
 #include "objects/object_link_child/object_link_child.h"
 #include "objects/object_test3/object_test3.h"
 void ResourceMgr_PatchGfxByName(const char* path, const char* patchName, int index, Gfx instruction);
@@ -83,4 +86,81 @@ void RegisterPlayAsKafei() {
 
     GameInteractor::Instance->RegisterGameHook<GameInteractor::OnSceneInit>(
         [](s8 sceneId, s8 spawnNum) { UpdatePlayAsKafeiOther(); });
+}
+
+u8 itemUsage;
+bool meterr;
+u8 timerrr;
+s16 timerrlimitt = 0;
+
+void RegisterALBWMeter() {
+    GameInteractor::Instance->RegisterGameHook<GameInteractor::OnPlayerUpdate>([]() {
+        if (CVarGetInteger("gModes.ALBWMeter", 0)) {
+            static u8 framesSinceMeter = 0;
+            static int8_t temp_ammo = gSaveContext.save.saveInfo.playerData.magic;
+            framesSinceMeter++;
+            if (temp_ammo != gSaveContext.save.saveInfo.playerData.magic) {
+                if (gSaveContext.save.saveInfo.playerData.magic < 0) {
+                    timerrlimitt = gSaveContext.save.saveInfo.playerData.magic * 10;
+                    gSaveContext.save.saveInfo.playerData.magic = 0;
+                }
+                meterr = true;
+                timerrr = 0;
+                temp_ammo = gSaveContext.save.saveInfo.playerData.magic;
+            }
+            if (meterr == true) {
+                timerrr++;
+                if (timerrr == 30 + abs(timerrlimitt)) {
+                    timerrr = 0;
+                    timerrlimitt = 0;
+                    meterr = false;
+                }
+            }
+            if (framesSinceMeter > 10 && meterr == false) {
+                framesSinceMeter = 0;
+                if (gSaveContext.save.saveInfo.playerData.magic < gSaveContext.magicCapacity) {
+                    gSaveContext.save.saveInfo.playerData.magic++;
+                    temp_ammo++;
+                } else if (gSaveContext.save.saveInfo.playerData.magic > gSaveContext.magicCapacity)
+                    gSaveContext.save.saveInfo.playerData.magic = temp_ammo = gSaveContext.magicCapacity;
+            }
+            float newAmmoAmount = (10 * gSaveContext.magicCapacity / 48) *
+                            (static_cast<float>(gSaveContext.save.saveInfo.playerData.magic) / gSaveContext.magicCapacity);
+            if (timerrlimitt == 0 || gSaveContext.save.saveInfo.playerData.magic > 0) {
+                if (floor(newAmmoAmount / 5) == 0)
+                    AMMO(ITEM_DEKU_STICK) = 1;
+                else
+                    AMMO(ITEM_DEKU_STICK) = newAmmoAmount / 5 + 1;
+                if (floor(newAmmoAmount / 5) == 0)
+                    AMMO(ITEM_DEKU_NUT) = 1;
+                else
+                    AMMO(ITEM_DEKU_NUT) = newAmmoAmount / 5 + 1;
+                if (floor(newAmmoAmount / 5) == 0)
+                    AMMO(ITEM_BOMB) = 1;
+                else
+                    AMMO(ITEM_BOMB) = newAmmoAmount / 5 + 1;
+                if (floor(newAmmoAmount / 2.5) == 0)
+                    AMMO(ITEM_BOW) = 1;
+                else
+                    AMMO(ITEM_BOW) = newAmmoAmount / 2.5 + 1;
+                if (floor(newAmmoAmount / 5) == 0)
+                    AMMO(ITEM_BOMBCHU) = 1;
+                else
+                    AMMO(ITEM_BOMBCHU) = newAmmoAmount / 5 + 1;
+            } else
+                AMMO(ITEM_DEKU_STICK) = AMMO(ITEM_DEKU_NUT) = AMMO(ITEM_BOMB) = AMMO(ITEM_BOW) = AMMO(ITEM_BOMBCHU) = 0;
+        }
+    });
+    GameInteractor::Instance->RegisterGameHook<GameInteractor::OnChangeAmmo>([](s16 item, s16 ammoChange) {
+        if (CVarGetInteger("gModes.ALBWMeter", 0)) {
+            if (item == ITEM_DEKU_STICK || item == ITEM_DEKU_NUT || item == ITEM_BOW || item == ITEM_BOMB ||
+                item == ITEM_BOMBCHU) {
+                if (item == ITEM_DEKU_NUT || item == ITEM_DEKU_STICK || item == ITEM_BOMB ||item == ITEM_BOMBCHU)
+                    itemUsage = 24;
+                else if (item == ITEM_BOW)
+                    itemUsage = 12;
+                gSaveContext.save.saveInfo.playerData.magic = gSaveContext.save.saveInfo.playerData.magic - itemUsage;
+            }
+        }
+    });
 }

--- a/mm/2s2h/Enhancements/Graphics/PlayAsKafei.h
+++ b/mm/2s2h/Enhancements/Graphics/PlayAsKafei.h
@@ -3,7 +3,7 @@
 
 void RegisterPlayAsKafei();
 void UpdatePlayAsKafeiSkeletons();
-void UpdatePlaayAsKafeiOther();
+void UpdatePlayAsKafeiOther();
 void RegisterALBWMeter();
 
 #endif // GRAPHICS_PLAY_AS_KAFEI_H

--- a/mm/2s2h/Enhancements/Graphics/PlayAsKafei.h
+++ b/mm/2s2h/Enhancements/Graphics/PlayAsKafei.h
@@ -3,6 +3,7 @@
 
 void RegisterPlayAsKafei();
 void UpdatePlayAsKafeiSkeletons();
-void UpdatePlayAsKafeiOther();
+void UpdatePlaayAsKafeiOther();
+void RegisterALBWMeter();
 
 #endif // GRAPHICS_PLAY_AS_KAFEI_H

--- a/mm/src/code/z_draw.c
+++ b/mm/src/code/z_draw.c
@@ -155,7 +155,7 @@ static DrawItemTableEntry sDrawItemTable[] = {
     // GID_MASK_ALL_NIGHT, OBJECT_GI_MASK06
     { GetItem_DrawOpa0Xlu1, { gGiAllNightMaskEyesDL, gGiAllNightMaskFaceDL } },
     // GID_DEKU_NUTS, OBJECT_GI_NUTS
-    { GetItem_DrawDekuNuts, { gGiNutDL } },
+    { GetItem_DrawDekuNuts, { gGiMagicJarSmallDL } },
     // GID_HEART_CONTAINER, OBJECT_GI_HEARTS
     { GetItem_DrawXlu01, { gGiHeartBorderDL, gGiHeartContainerDL } },
     // GID_HEART_PIECE, OBJECT_GI_HEARTS
@@ -173,7 +173,7 @@ static DrawItemTableEntry sDrawItemTable[] = {
     // GID_BOMB_BAG_40, OBJECT_GI_BOMBPOUCH
     { GetItem_DrawUpgrades, { gGiBombBagDL, gGiBombBag40BagColorDL, gGiBombBag40RingColorDL, gGiBombBagRingDL } },
     // GID_DEKU_STICK, OBJECT_GI_STICK
-    { GetItem_DrawOpa0, { gGiStickDL } },
+    { GetItem_DrawOpa0, { gGiMagicJarSmallDL } },
     // GID_DUNGEON_MAP, OBJECT_GI_MAP
     { GetItem_DrawOpa0, { gGiDungeonMapDL } },
     // GID_MAGIC_JAR_SMALL, OBJECT_GI_MAGICPOT
@@ -181,7 +181,7 @@ static DrawItemTableEntry sDrawItemTable[] = {
     // GID_MAGIC_JAR_BIG, OBJECT_GI_MAGICPOT
     { GetItem_DrawOpa0, { gGiMagicJarLargeDL } },
     // GID_BOMB, OBJECT_GI_BOMB_1
-    { GetItem_DrawOpa0, { gGiBombDL } },
+    { GetItem_DrawOpa0, { gGiMagicJarLargeDL } },
     // GID_STONE_OF_AGONY, OBJECT_GI_MAP
     { GetItem_DrawOpa0, { gGiStoneOfAgonyDL } },
     // GID_WALLET_ADULT, OBJECT_GI_PURSE
@@ -195,13 +195,13 @@ static DrawItemTableEntry sDrawItemTable[] = {
     // GID_MASK_DON_GERO, OBJECT_GI_MASK16
     { GetItem_DrawOpa0Xlu1, { gGiDonGeroMaskFaceDL, gGiDonGeroMaskBodyDL } },
     // GID_ARROWS_SMALL, OBJECT_GI_ARROW
-    { GetItem_DrawOpa0, { gGiArrowSmallDL } },
+    { GetItem_DrawOpa0, { gGiMagicJarSmallDL } },
     // GID_ARROWS_MEDIUM, OBJECT_GI_ARROW
-    { GetItem_DrawOpa0, { gGiArrowMediumDL } },
+    { GetItem_DrawOpa0, { gGiMagicJarSmallDL } },
     // GID_ARROWS_LARGE, OBJECT_GI_ARROW
-    { GetItem_DrawOpa0, { gGiArrowLargeDL } },
+    { GetItem_DrawOpa0, { gGiMagicJarLargeDL } },
     // GID_BOMBCHU, OBJECT_GI_BOMB_2
-    { GetItem_DrawBombchu, { gGiBombchuDL } },
+    { GetItem_DrawBombchu, { gGiMagicJarLargeDL } },
     // GID_SHIELD_HERO, OBJECT_GI_SHIELD_2
     { GetItem_DrawOpa0Xlu1, { gGiHerosShieldEmblemDL, gGiHerosShieldDL } },
     // GID_HOOKSHOT, OBJECT_GI_HOOKSHOT

--- a/mm/src/code/z_en_item00.c
+++ b/mm/src/code/z_en_item00.c
@@ -807,13 +807,13 @@ void EnItem00_DrawRupee(EnItem00* this, PlayState* play) {
 
 TexturePtr sItemDropTextures[] = {
     gDropRecoveryHeartTex, // Heart (Not used)
-    gDropMagicLargeTex,          // Bombs (A), Bombs (0)
-    gDropMagicSmallTex,       // Arrows (10)
-    gDropMagicSmallTex,       // Arrows (30)
-    gDropMagicLargeTex,       // Arrows (40), Arrows (50)
-    gDropMagicLargeTex,          // Bombs (B)
-    gDropMagicSmallTex,       // Nuts (1), Nuts (10)
-    gDropMagicSmallTex,     // Sticks (1)
+    gDropMagicLargeTex,    // Bombs (A), Bombs (0)
+    gDropMagicSmallTex,    // Arrows (10)
+    gDropMagicSmallTex,    // Arrows (30)
+    gDropMagicLargeTex,    // Arrows (40), Arrows (50)
+    gDropMagicLargeTex,    // Bombs (B)
+    gDropMagicSmallTex,    // Nuts (1), Nuts (10)
+    gDropMagicSmallTex,    // Sticks (1)
     gDropMagicLargeTex,    // Magic (Large)
     gDropMagicSmallTex,    // Magic (Small)
     NULL,

--- a/mm/src/code/z_en_item00.c
+++ b/mm/src/code/z_en_item00.c
@@ -573,15 +573,18 @@ void EnItem00_Update(Actor* thisx, PlayState* play) {
             break;
 
         case ITEM00_DEKU_STICK:
-            Item_Give(play, ITEM_MAGIC_JAR_SMALL);
+            if (CVarGetInteger("gModes.ALBWMeter", 0)) Item_Give(play, ITEM_MAGIC_JAR_SMALL); else
+            getItemId = GI_DEKU_STICKS_1;
             break;
 
         case ITEM00_DEKU_NUTS_1:
-            Item_Give(play, ITEM_MAGIC_JAR_SMALL);
+            if (CVarGetInteger("gModes.ALBWMeter", 0)) Item_Give(play, ITEM_MAGIC_JAR_SMALL); else
+            getItemId = GI_DEKU_NUTS_1;
             break;
 
         case ITEM00_DEKU_NUTS_10:
-            Item_Give(play, ITEM_MAGIC_JAR_SMALL);
+            if (CVarGetInteger("gModes.ALBWMeter", 0)) Item_Give(play, ITEM_MAGIC_JAR_SMALL); else
+            getItemId = GI_DEKU_NUTS_10;
             break;
 
         case ITEM00_RECOVERY_HEART:
@@ -595,23 +598,28 @@ void EnItem00_Update(Actor* thisx, PlayState* play) {
 
         case ITEM00_BOMBS_A:
         case ITEM00_BOMBS_B:
-            Item_Give(play, ITEM_MAGIC_JAR_BIG);
+            if (CVarGetInteger("gModes.ALBWMeter", 0)) Item_Give(play, ITEM_MAGIC_JAR_BIG); else
+            Item_Give(play, ITEM_BOMBS_5);
             break;
 
         case ITEM00_ARROWS_10:
-            Item_Give(play, ITEM_MAGIC_JAR_SMALL);
+            if (CVarGetInteger("gModes.ALBWMeter", 0)) Item_Give(play, ITEM_MAGIC_JAR_SMALL); else
+            Item_Give(play, ITEM_ARROWS_10);
             break;
 
         case ITEM00_ARROWS_30:
-            Item_Give(play, ITEM_MAGIC_JAR_SMALL);
+            if (CVarGetInteger("gModes.ALBWMeter", 0)) Item_Give(play, ITEM_MAGIC_JAR_SMALL); else
+            Item_Give(play, ITEM_ARROWS_30);
             break;
 
         case ITEM00_ARROWS_40:
-            Item_Give(play, ITEM_MAGIC_JAR_BIG);
+            if (CVarGetInteger("gModes.ALBWMeter", 0)) Item_Give(play, ITEM_MAGIC_JAR_BIG); else
+            Item_Give(play, ITEM_ARROWS_40);
             break;
 
         case ITEM00_ARROWS_50:
-            Item_Give(play, ITEM_MAGIC_JAR_BIG);
+            if (CVarGetInteger("gModes.ALBWMeter", 0)) Item_Give(play, ITEM_MAGIC_JAR_BIG); else
+            Item_Give(play, ITEM_ARROWS_50);
             break;
 
         case ITEM00_SMALL_KEY:
@@ -703,6 +711,7 @@ void EnItem00_Update(Actor* thisx, PlayState* play) {
 void EnItem00_Draw(Actor* thisx, PlayState* play) {
     s32 pad;
     EnItem00* this = THIS;
+    f32 mtxScale;
 
     if (!(this->unk14E & this->unk150)) {
         switch (this->actor.params) {
@@ -739,20 +748,54 @@ void EnItem00_Draw(Actor* thisx, PlayState* play) {
                     break;
                 }
                 // fallthrough
+            case ITEM00_BOMBS_0:
             case ITEM00_BOMBS_A:
+            case ITEM00_BOMBS_B:
+                mtxScale = 8.0f;
+                Matrix_Scale(mtxScale, mtxScale, mtxScale, MTXMODE_APPLY);
+                GetItem_Draw(play, GID_BOMB);
+                break;
             case ITEM00_ARROWS_10:
             case ITEM00_ARROWS_30:
+                mtxScale = 7.0f;
+                Matrix_Scale(mtxScale, mtxScale, mtxScale, MTXMODE_APPLY);
+                GetItem_Draw(play, GID_ARROWS_SMALL);
+                break;
             case ITEM00_ARROWS_40:
+                mtxScale = 7.0f;
+                Matrix_Scale(mtxScale, mtxScale, mtxScale, MTXMODE_APPLY);
+                GetItem_Draw(play, GID_ARROWS_MEDIUM);
+                break;
             case ITEM00_ARROWS_50:
-            case ITEM00_BOMBS_B:
+                mtxScale = 7.0f;
+                Matrix_Scale(mtxScale, mtxScale, mtxScale, MTXMODE_APPLY);
+                GetItem_Draw(play, GID_ARROWS_LARGE);
+                break;
             case ITEM00_DEKU_NUTS_1:
-            case ITEM00_DEKU_STICK:
-            case ITEM00_MAGIC_JAR_BIG:
-            case ITEM00_MAGIC_JAR_SMALL:
-            case ITEM00_SMALL_KEY:
             case ITEM00_DEKU_NUTS_10:
-            case ITEM00_BOMBS_0:
-                EnItem00_DrawSprite(this, play);
+                mtxScale = 9.0f;
+                Matrix_Scale(mtxScale, mtxScale, mtxScale, MTXMODE_APPLY);
+                GetItem_Draw(play, GID_DEKU_NUTS);
+                break;
+            case ITEM00_DEKU_STICK:
+                mtxScale = 7.5f;
+                Matrix_Scale(mtxScale, mtxScale, mtxScale, MTXMODE_APPLY);
+                GetItem_Draw(play, GID_DEKU_STICK);
+                break;
+            case ITEM00_MAGIC_JAR_BIG:
+                mtxScale = 8.0f;
+                Matrix_Scale(mtxScale, mtxScale, mtxScale, MTXMODE_APPLY);
+                GetItem_Draw(play, GID_MAGIC_JAR_BIG);
+                break;
+            case ITEM00_MAGIC_JAR_SMALL:
+                mtxScale = 8.0f;
+                Matrix_Scale(mtxScale, mtxScale, mtxScale, MTXMODE_APPLY);
+                GetItem_Draw(play, GID_MAGIC_JAR_SMALL);
+                break;
+            case ITEM00_SMALL_KEY:
+                mtxScale = 8.0f;
+                Matrix_Scale(mtxScale, mtxScale, mtxScale, MTXMODE_APPLY);
+                GetItem_Draw(play, GID_KEY_SMALL);
                 break;
 
             case ITEM00_SHIELD_HERO:
@@ -807,13 +850,13 @@ void EnItem00_DrawRupee(EnItem00* this, PlayState* play) {
 
 TexturePtr sItemDropTextures[] = {
     gDropRecoveryHeartTex, // Heart (Not used)
-    gDropMagicLargeTex,    // Bombs (A), Bombs (0)
-    gDropMagicSmallTex,    // Arrows (10)
-    gDropMagicSmallTex,    // Arrows (30)
-    gDropMagicLargeTex,    // Arrows (40), Arrows (50)
-    gDropMagicLargeTex,    // Bombs (B)
-    gDropMagicSmallTex,    // Nuts (1), Nuts (10)
-    gDropMagicSmallTex,    // Sticks (1)
+    gDropBombTex,          // Bombs (A), Bombs (0)
+    gDropArrows1Tex,       // Arrows (10)
+    gDropArrows2Tex,       // Arrows (30)
+    gDropArrows3Tex,       // Arrows (40), Arrows (50)
+    gDropBombTex,          // Bombs (B)
+    gDropDekuNutTex,       // Nuts (1), Nuts (10)
+    gDropDekuStickTex,     // Sticks (1)
     gDropMagicLargeTex,    // Magic (Large)
     gDropMagicSmallTex,    // Magic (Small)
     NULL,
@@ -828,15 +871,17 @@ void EnItem00_DrawSprite(EnItem00* this, PlayState* play) {
     POLY_OPA_DISP = Play_SetFog(play, POLY_OPA_DISP);
 
     if (this->actor.params == ITEM00_DEKU_NUTS_10) {
+        if (CVarGetInteger("gModes.ALBWMeter", 0)) texIndex = 9; else
         texIndex = 6;
     } else if (this->actor.params == ITEM00_BOMBS_0) {
+        if (CVarGetInteger("gModes.ALBWMeter", 0)) texIndex = 8; else
         texIndex = 1;
-    } else if (this->actor.params >= ITEM00_ARROWS_30) {
+    } else if (this->actor.params >= ITEM00_ARROWS_30 && (CVarGetInteger("gModes.ALBWMeter", 0) == 0)) {
         texIndex -= 3;
         if (this->actor.params < ITEM00_ARROWS_50) {
             texIndex++;
         }
-    }
+    } else if (this->actor.params == ITEM00_ARROWS_10 || this->actor.params == ITEM00_ARROWS_30) {texIndex = 9;} else if (this->actor.params == ITEM00_ARROWS_40 || this->actor.params == ITEM00_ARROWS_50) texIndex = 8;
 
     POLY_OPA_DISP = Gfx_SetupDL66(POLY_OPA_DISP);
 

--- a/mm/src/code/z_en_item00.c
+++ b/mm/src/code/z_en_item00.c
@@ -573,15 +573,15 @@ void EnItem00_Update(Actor* thisx, PlayState* play) {
             break;
 
         case ITEM00_DEKU_STICK:
-            getItemId = GI_DEKU_STICKS_1;
+            Item_Give(play, ITEM_MAGIC_JAR_SMALL);
             break;
 
         case ITEM00_DEKU_NUTS_1:
-            getItemId = GI_DEKU_NUTS_1;
+            Item_Give(play, ITEM_MAGIC_JAR_SMALL);
             break;
 
         case ITEM00_DEKU_NUTS_10:
-            getItemId = GI_DEKU_NUTS_10;
+            Item_Give(play, ITEM_MAGIC_JAR_SMALL);
             break;
 
         case ITEM00_RECOVERY_HEART:
@@ -595,23 +595,23 @@ void EnItem00_Update(Actor* thisx, PlayState* play) {
 
         case ITEM00_BOMBS_A:
         case ITEM00_BOMBS_B:
-            Item_Give(play, ITEM_BOMBS_5);
+            Item_Give(play, ITEM_MAGIC_JAR_BIG);
             break;
 
         case ITEM00_ARROWS_10:
-            Item_Give(play, ITEM_ARROWS_10);
+            Item_Give(play, ITEM_MAGIC_JAR_SMALL);
             break;
 
         case ITEM00_ARROWS_30:
-            Item_Give(play, ITEM_ARROWS_30);
+            Item_Give(play, ITEM_MAGIC_JAR_SMALL);
             break;
 
         case ITEM00_ARROWS_40:
-            Item_Give(play, ITEM_ARROWS_40);
+            Item_Give(play, ITEM_MAGIC_JAR_BIG);
             break;
 
         case ITEM00_ARROWS_50:
-            Item_Give(play, ITEM_ARROWS_50);
+            Item_Give(play, ITEM_MAGIC_JAR_BIG);
             break;
 
         case ITEM00_SMALL_KEY:
@@ -807,13 +807,13 @@ void EnItem00_DrawRupee(EnItem00* this, PlayState* play) {
 
 TexturePtr sItemDropTextures[] = {
     gDropRecoveryHeartTex, // Heart (Not used)
-    gDropBombTex,          // Bombs (A), Bombs (0)
-    gDropArrows1Tex,       // Arrows (10)
-    gDropArrows2Tex,       // Arrows (30)
-    gDropArrows3Tex,       // Arrows (40), Arrows (50)
-    gDropBombTex,          // Bombs (B)
-    gDropDekuNutTex,       // Nuts (1), Nuts (10)
-    gDropDekuStickTex,     // Sticks (1)
+    gDropMagicLargeTex,          // Bombs (A), Bombs (0)
+    gDropMagicSmallTex,       // Arrows (10)
+    gDropMagicSmallTex,       // Arrows (30)
+    gDropMagicLargeTex,       // Arrows (40), Arrows (50)
+    gDropMagicLargeTex,          // Bombs (B)
+    gDropMagicSmallTex,       // Nuts (1), Nuts (10)
+    gDropMagicSmallTex,     // Sticks (1)
     gDropMagicLargeTex,    // Magic (Large)
     gDropMagicSmallTex,    // Magic (Small)
     NULL,

--- a/mm/src/code/z_parameter.c
+++ b/mm/src/code/z_parameter.c
@@ -4941,8 +4941,8 @@ void Magic_Update(PlayState* play) {
                     sMagicMeterOutlinePrimRed = sMagicMeterOutlinePrimGreen = sMagicMeterOutlinePrimBlue = 255;
                     break;
                 }
-
-                interfaceCtx->magicConsumptionTimer -= 10;
+                if (CVarGetInteger("gModes.ALBWMeter", 0)) interfaceCtx->magicConsumptionTimer -= 10;
+                else interfaceCtx->magicConsumptionTimer--;
                 if (interfaceCtx->magicConsumptionTimer == 0) {
                     if (!CHECK_WEEKEVENTREG(WEEKEVENTREG_DRANK_CHATEAU_ROMANI)) {
                         gSaveContext.save.saveInfo.playerData.magic--;

--- a/mm/src/code/z_parameter.c
+++ b/mm/src/code/z_parameter.c
@@ -29,6 +29,7 @@ const char* sCounterTextures[] = {
     gCounterDigit6Tex, gCounterDigit7Tex, gCounterDigit8Tex, gCounterDigit9Tex, gCounterColonTex,
 };
 
+
 static const char* sDoWeekTable[] = {
     gClockDay1stTex,
     gClockDay2ndTex,

--- a/mm/src/code/z_parameter.c
+++ b/mm/src/code/z_parameter.c
@@ -4527,53 +4527,10 @@ void Rupees_ChangeBy(s16 rupeeChange) {
     gSaveContext.rupeeAccumulator += rupeeChange;
 }
 
+u8 itemUsage;
+
 void Inventory_ChangeAmmo(s16 item, s16 ammoChange) {
-    if (item == ITEM_DEKU_STICK) {
-        AMMO(ITEM_DEKU_STICK) += ammoChange;
-
-        if (AMMO(ITEM_DEKU_STICK) >= CUR_CAPACITY(UPG_DEKU_STICKS)) {
-            AMMO(ITEM_DEKU_STICK) = CUR_CAPACITY(UPG_DEKU_STICKS);
-        } else if (AMMO(ITEM_DEKU_STICK) < 0) {
-            AMMO(ITEM_DEKU_STICK) = 0;
-        }
-
-    } else if (item == ITEM_DEKU_NUT) {
-        AMMO(ITEM_DEKU_NUT) += ammoChange;
-
-        if (AMMO(ITEM_DEKU_NUT) >= CUR_CAPACITY(UPG_DEKU_NUTS)) {
-            AMMO(ITEM_DEKU_NUT) = CUR_CAPACITY(UPG_DEKU_NUTS);
-        } else if (AMMO(ITEM_DEKU_NUT) < 0) {
-            AMMO(ITEM_DEKU_NUT) = 0;
-        }
-
-    } else if (item == ITEM_BOMBCHU) {
-        AMMO(ITEM_BOMBCHU) += ammoChange;
-
-        if (AMMO(ITEM_BOMBCHU) >= CUR_CAPACITY(UPG_BOMB_BAG)) {
-            AMMO(ITEM_BOMBCHU) = CUR_CAPACITY(UPG_BOMB_BAG);
-        } else if (AMMO(ITEM_BOMBCHU) < 0) {
-            AMMO(ITEM_BOMBCHU) = 0;
-        }
-
-    } else if (item == ITEM_BOW) {
-        AMMO(ITEM_BOW) += ammoChange;
-
-        if (AMMO(ITEM_BOW) >= CUR_CAPACITY(UPG_QUIVER)) {
-            AMMO(ITEM_BOW) = CUR_CAPACITY(UPG_QUIVER);
-        } else if (AMMO(ITEM_BOW) < 0) {
-            AMMO(ITEM_BOW) = 0;
-        }
-
-    } else if (item == ITEM_BOMB) {
-        AMMO(ITEM_BOMB) += ammoChange;
-
-        if (AMMO(ITEM_BOMB) >= CUR_CAPACITY(UPG_BOMB_BAG)) {
-            AMMO(ITEM_BOMB) = CUR_CAPACITY(UPG_BOMB_BAG);
-        } else if (AMMO(ITEM_BOMB) < 0) {
-            AMMO(ITEM_BOMB) = 0;
-        }
-
-    } else if (item == ITEM_MAGIC_BEANS) {
+    if (item == ITEM_MAGIC_BEANS) {
         AMMO(ITEM_MAGIC_BEANS) += ammoChange;
 
     } else if (item == ITEM_POWDER_KEG) {
@@ -4584,6 +4541,13 @@ void Inventory_ChangeAmmo(s16 item, s16 ammoChange) {
             AMMO(ITEM_POWDER_KEG) = 0;
         }
     }
+
+    if (item == ITEM_DEKU_STICK || item == ITEM_DEKU_NUT || item == ITEM_BOW || item == ITEM_BOMB || item == ITEM_BOMBCHU) {
+        if (item == ITEM_DEKU_NUT || ITEM_DEKU_STICK || ITEM_BOMB || ITEM_BOMBCHU) itemUsage = 24;
+        else if (item == ITEM_BOW) itemUsage = 12;
+        gSaveContext.save.saveInfo.playerData.magic = gSaveContext.save.saveInfo.playerData.magic - itemUsage;
+    }
+
 }
 
 void Magic_Add(PlayState* play, s16 magicToAdd) {
@@ -4823,7 +4787,9 @@ void Magic_Update(PlayState* play) {
         case MAGIC_STATE_STEP_CAPACITY:
             // Step magicCapacity to the capacity determined by magicLevel
             // This changes the width of the magic meter drawn
-            magicCapacityTarget = gSaveContext.save.saveInfo.playerData.magicLevel * MAGIC_NORMAL_METER;
+            if (gSaveContext.save.saveInfo.playerData.magicLevel == 2) magicCapacityTarget = MAGIC_NORMAL_METER;
+            else if (gSaveContext.save.saveInfo.playerData.magicLevel == 1) magicCapacityTarget = 0.5 * MAGIC_NORMAL_METER;
+            else magicCapacityTarget = 0;
             if (gSaveContext.magicCapacity != magicCapacityTarget) {
                 if (gSaveContext.magicCapacity < magicCapacityTarget) {
                     gSaveContext.magicCapacity += 0x10;
@@ -4917,7 +4883,7 @@ void Magic_Update(PlayState* play) {
                     break;
                 }
 
-                interfaceCtx->magicConsumptionTimer--;
+                interfaceCtx->magicConsumptionTimer -= 10;
                 if (interfaceCtx->magicConsumptionTimer == 0) {
                     if (!CHECK_WEEKEVENTREG(WEEKEVENTREG_DRANK_CHATEAU_ROMANI)) {
                         gSaveContext.save.saveInfo.playerData.magic--;
@@ -5068,7 +5034,7 @@ void Magic_DrawMeter(PlayState* play) {
                 gDPSetPrimColor(OVERLAY_DISP++, 0, 0, 0, 0, 200, interfaceCtx->magicAlpha);
             } else {
                 // Green magic (default)
-                gDPSetPrimColor(OVERLAY_DISP++, 0, 0, 0, 200, 0, interfaceCtx->magicAlpha);
+                gDPSetPrimColor(OVERLAY_DISP++, 0, 0, 203, 82, 255, interfaceCtx->magicAlpha);
             }
 
             // #region 2S2H [Cosmetic] Hud Editor
@@ -5108,7 +5074,7 @@ void Magic_DrawMeter(PlayState* play) {
                 gDPSetPrimColor(OVERLAY_DISP++, 0, 0, 0, 0, 200, interfaceCtx->magicAlpha);
             } else {
                 // Green magic (default)
-                gDPSetPrimColor(OVERLAY_DISP++, 0, 0, 0, 200, 0, interfaceCtx->magicAlpha);
+                gDPSetPrimColor(OVERLAY_DISP++, 0, 0, 203, 82, 255, interfaceCtx->magicAlpha);
             }
 
             gDPLoadTextureBlock_4b(OVERLAY_DISP++, gMagicMeterFillTex, G_IM_FMT_I, 16, 16, 0, G_TX_NOMIRROR | G_TX_WRAP,

--- a/mm/src/code/z_parameter.c
+++ b/mm/src/code/z_parameter.c
@@ -2907,6 +2907,14 @@ void Interface_UpdateButtonsPart2(PlayState* play) {
                             }
                         }
                     }
+                    if (CVarGetInteger("gModes.ALBWMeter", 0) && gSaveContext.save.saveInfo.playerData.magic < 1) {
+                        if (GET_CUR_FORM_BTN_ITEM(i) == ITEM_HOOKSHOT) {
+                            if ((gSaveContext.buttonStatus[i] == BTN_ENABLED)) {
+                                restoreHudVisibility = true;
+                                gSaveContext.buttonStatus[i] = BTN_DISABLED;
+                            }
+                        }
+                    }
                 }
             }
             // #region 2S2H [Dpad]
@@ -3051,6 +3059,14 @@ void Interface_UpdateButtonsPart2(PlayState* play) {
                             if ((gSaveContext.shipSaveContext.dpad.status[j] == BTN_DISABLED)) {
                                 restoreHudVisibility = true;
                                 gSaveContext.shipSaveContext.dpad.status[j] = BTN_ENABLED;
+                            }
+                        }
+                    }
+                    if (CVarGetInteger("gModes.ALBWMeter", 0) && gSaveContext.save.saveInfo.playerData.magic < 1) {
+                        if (GET_CUR_FORM_BTN_ITEM(j) == ITEM_HOOKSHOT) {
+                            if ((gSaveContext.shipSaveContext.dpad.status[j] == BTN_ENABLED)) {
+                                restoreHudVisibility = true;
+                                gSaveContext.shipSaveContext.dpad.status[j] = BTN_DISABLED;
                             }
                         }
                     }
@@ -4527,10 +4543,54 @@ void Rupees_ChangeBy(s16 rupeeChange) {
     gSaveContext.rupeeAccumulator += rupeeChange;
 }
 
-u8 itemUsage;
-
 void Inventory_ChangeAmmo(s16 item, s16 ammoChange) {
-    if (item == ITEM_MAGIC_BEANS) {
+    GameInteractor_ExecuteOnChangeAmmoHooks(item, ammoChange);
+        if (item == ITEM_DEKU_STICK) {
+        AMMO(ITEM_DEKU_STICK) += ammoChange;
+
+        if (AMMO(ITEM_DEKU_STICK) >= CUR_CAPACITY(UPG_DEKU_STICKS)) {
+            AMMO(ITEM_DEKU_STICK) = CUR_CAPACITY(UPG_DEKU_STICKS);
+        } else if (AMMO(ITEM_DEKU_STICK) < 0) {
+            AMMO(ITEM_DEKU_STICK) = 0;
+        }
+
+    } else if (item == ITEM_DEKU_NUT) {
+        AMMO(ITEM_DEKU_NUT) += ammoChange;
+
+        if (AMMO(ITEM_DEKU_NUT) >= CUR_CAPACITY(UPG_DEKU_NUTS)) {
+            AMMO(ITEM_DEKU_NUT) = CUR_CAPACITY(UPG_DEKU_NUTS);
+        } else if (AMMO(ITEM_DEKU_NUT) < 0) {
+            AMMO(ITEM_DEKU_NUT) = 0;
+        }
+
+    } else if (item == ITEM_BOMBCHU) {
+        AMMO(ITEM_BOMBCHU) += ammoChange;
+
+        if (AMMO(ITEM_BOMBCHU) >= CUR_CAPACITY(UPG_BOMB_BAG)) {
+            AMMO(ITEM_BOMBCHU) = CUR_CAPACITY(UPG_BOMB_BAG);
+        } else if (AMMO(ITEM_BOMBCHU) < 0) {
+            AMMO(ITEM_BOMBCHU) = 0;
+        }
+
+    } else if (item == ITEM_BOW) {
+        AMMO(ITEM_BOW) += ammoChange;
+
+        if (AMMO(ITEM_BOW) >= CUR_CAPACITY(UPG_QUIVER)) {
+            AMMO(ITEM_BOW) = CUR_CAPACITY(UPG_QUIVER);
+        } else if (AMMO(ITEM_BOW) < 0) {
+            AMMO(ITEM_BOW) = 0;
+        }
+
+    } else if (item == ITEM_BOMB) {
+        AMMO(ITEM_BOMB) += ammoChange;
+
+        if (AMMO(ITEM_BOMB) >= CUR_CAPACITY(UPG_BOMB_BAG)) {
+            AMMO(ITEM_BOMB) = CUR_CAPACITY(UPG_BOMB_BAG);
+        } else if (AMMO(ITEM_BOMB) < 0) {
+            AMMO(ITEM_BOMB) = 0;
+        }
+
+    } else if (item == ITEM_MAGIC_BEANS) {
         AMMO(ITEM_MAGIC_BEANS) += ammoChange;
 
     } else if (item == ITEM_POWDER_KEG) {
@@ -4541,13 +4601,6 @@ void Inventory_ChangeAmmo(s16 item, s16 ammoChange) {
             AMMO(ITEM_POWDER_KEG) = 0;
         }
     }
-
-    if (item == ITEM_DEKU_STICK || item == ITEM_DEKU_NUT || item == ITEM_BOW || item == ITEM_BOMB || item == ITEM_BOMBCHU) {
-        if (item == ITEM_DEKU_NUT || ITEM_DEKU_STICK || ITEM_BOMB || ITEM_BOMBCHU) itemUsage = 24;
-        else if (item == ITEM_BOW) itemUsage = 12;
-        gSaveContext.save.saveInfo.playerData.magic = gSaveContext.save.saveInfo.playerData.magic - itemUsage;
-    }
-
 }
 
 void Magic_Add(PlayState* play, s16 magicToAdd) {
@@ -4787,9 +4840,15 @@ void Magic_Update(PlayState* play) {
         case MAGIC_STATE_STEP_CAPACITY:
             // Step magicCapacity to the capacity determined by magicLevel
             // This changes the width of the magic meter drawn
-            if (gSaveContext.save.saveInfo.playerData.magicLevel == 2) magicCapacityTarget = MAGIC_NORMAL_METER;
-            else if (gSaveContext.save.saveInfo.playerData.magicLevel == 1) magicCapacityTarget = 0.5 * MAGIC_NORMAL_METER;
-            else magicCapacityTarget = 0;
+            if (CVarGetInteger("gModes.ALBWMeter", 0)) {
+                if (gSaveContext.save.saveInfo.playerData.magicLevel == 2)
+                    magicCapacityTarget = MAGIC_NORMAL_METER;
+                else if (gSaveContext.save.saveInfo.playerData.magicLevel == 1)
+                    magicCapacityTarget = 0.5 * MAGIC_NORMAL_METER;
+                else
+                    magicCapacityTarget = 0;
+            }
+            else magicCapacityTarget = gSaveContext.save.saveInfo.playerData.magicLevel * MAGIC_NORMAL_METER;
             if (gSaveContext.magicCapacity != magicCapacityTarget) {
                 if (gSaveContext.magicCapacity < magicCapacityTarget) {
                     gSaveContext.magicCapacity += 0x10;
@@ -5034,7 +5093,8 @@ void Magic_DrawMeter(PlayState* play) {
                 gDPSetPrimColor(OVERLAY_DISP++, 0, 0, 0, 0, 200, interfaceCtx->magicAlpha);
             } else {
                 // Green magic (default)
-                gDPSetPrimColor(OVERLAY_DISP++, 0, 0, 203, 82, 255, interfaceCtx->magicAlpha);
+                if (CVarGetInteger("gModes.ALBWMeter", 0)) gDPSetPrimColor(OVERLAY_DISP++, 0, 0, 203, 82, 255, interfaceCtx->magicAlpha);
+                else gDPSetPrimColor(OVERLAY_DISP++, 0, 0, 0, 200, 0, interfaceCtx->magicAlpha);
             }
 
             // #region 2S2H [Cosmetic] Hud Editor
@@ -5074,7 +5134,8 @@ void Magic_DrawMeter(PlayState* play) {
                 gDPSetPrimColor(OVERLAY_DISP++, 0, 0, 0, 0, 200, interfaceCtx->magicAlpha);
             } else {
                 // Green magic (default)
-                gDPSetPrimColor(OVERLAY_DISP++, 0, 0, 203, 82, 255, interfaceCtx->magicAlpha);
+                if (CVarGetInteger("gModes.ALBWMeter", 0)) gDPSetPrimColor(OVERLAY_DISP++, 0, 0, 203, 82, 255, interfaceCtx->magicAlpha);
+                else gDPSetPrimColor(OVERLAY_DISP++, 0, 0, 0, 200, 0, interfaceCtx->magicAlpha);
             }
 
             gDPLoadTextureBlock_4b(OVERLAY_DISP++, gMagicMeterFillTex, G_IM_FMT_I, 16, 16, 0, G_TX_NOMIRROR | G_TX_WRAP,
@@ -9073,7 +9134,8 @@ void Interface_Update(PlayState* play) {
                 gSaveContext.save.saveInfo.playerData.isMagicAcquired = true;
             }
             gSaveContext.save.saveInfo.playerData.isDoubleMagicAcquired = true;
-            gSaveContext.save.saveInfo.playerData.magic = MAGIC_DOUBLE_METER;
+            if (CVarGetInteger("gModes.ALBWMeter", 0)) gSaveContext.save.saveInfo.playerData.magic = 0x30;
+            else gSaveContext.save.saveInfo.playerData.magic = MAGIC_DOUBLE_METER;
             gSaveContext.save.saveInfo.playerData.magicLevel = 0;
             R_MAGIC_DBG_SET_UPGRADE = MAGIC_DBG_SET_UPGRADE_NO_ACTION;
         } else if (R_MAGIC_DBG_SET_UPGRADE == MAGIC_DBG_SET_UPGRADE_NORMAL_METER) {
@@ -9082,6 +9144,7 @@ void Interface_Update(PlayState* play) {
                 gSaveContext.save.saveInfo.playerData.isMagicAcquired = true;
             }
             gSaveContext.save.saveInfo.playerData.isDoubleMagicAcquired = false;
+            if (CVarGetInteger("gModes.ALBWMeter", 0)) gSaveContext.save.saveInfo.playerData.magic = MAGIC_NORMAL_METER * 0.5;
             gSaveContext.save.saveInfo.playerData.magic = MAGIC_NORMAL_METER;
             gSaveContext.save.saveInfo.playerData.magicLevel = 0;
             R_MAGIC_DBG_SET_UPGRADE = MAGIC_DBG_SET_UPGRADE_NO_ACTION;

--- a/mm/src/code/z_parameter.c
+++ b/mm/src/code/z_parameter.c
@@ -29,7 +29,6 @@ const char* sCounterTextures[] = {
     gCounterDigit6Tex, gCounterDigit7Tex, gCounterDigit8Tex, gCounterDigit9Tex, gCounterColonTex,
 };
 
-
 static const char* sDoWeekTable[] = {
     gClockDay1stTex,
     gClockDay2ndTex,

--- a/mm/src/overlays/actors/ovl_Arms_Hook/z_arms_hook.c
+++ b/mm/src/overlays/actors/ovl_Arms_Hook/z_arms_hook.c
@@ -125,7 +125,8 @@ void ArmsHook_AttachHookToActor(ArmsHook* this, Actor* actor) {
     this->grabbed = actor;
     Math_Vec3f_Diff(&actor->world.pos, &this->actor.world.pos, &this->unk1FC);
 }
-
+bool hook1Frame = false;
+bool hookshotMoment = false;
 void ArmsHook_Shoot(ArmsHook* this, PlayState* play) {
     Player* player = GET_PLAYER(play);
 
@@ -134,6 +135,7 @@ void ArmsHook_Shoot(ArmsHook* this, PlayState* play) {
         Actor_Kill(&this->actor);
         return;
     }
+    if (CVarGetInteger("gModes.ALBWMeter", 0)) {if (hook1Frame != true) {hook1Frame = true; gSaveContext.save.saveInfo.playerData.magic -= 6;} hookshotMoment = true;}
 
     Actor_PlaySfx_FlaggedCentered1(&player->actor, NA_SE_IT_HOOKSHOT_CHAIN - SFX_FLAG);
     ArmsHook_CheckForCancel(this);
@@ -280,6 +282,11 @@ void ArmsHook_Update(Actor* thisx, PlayState* play) {
 
     this->actionFunc(this, play);
     this->unk1EC = this->unk1E0;
+
+    if (CVarGetInteger("gModes.ALBWMeter", 0)) {
+        if (hook1Frame && !hookshotMoment) hook1Frame = false;
+        hookshotMoment = false;
+    }
 }
 
 Vec3f D_808C1C10 = { 0.0f, 0.0f, 0.0f };

--- a/mm/src/overlays/actors/ovl_player_actor/z_player.c
+++ b/mm/src/overlays/actors/ovl_player_actor/z_player.c
@@ -51,6 +51,7 @@
 
 void Player_Init(Actor* thisx, PlayState* play);
 void Player_Destroy(Actor* thisx, PlayState* play);
+void RegisterMeterStuff();
 void Player_Update(Actor* thisx, PlayState* play);
 void Player_Draw(Actor* thisx, PlayState* play);
 
@@ -12580,6 +12581,63 @@ s32 Player_UpdateNoclip(Player* this, PlayState* play) {
     return true;
 }
 
+u8 noooooo;
+float ddddd;
+u8 my_floor_2(float num) {
+
+    ddddd = num;
+    noooooo = (u8)num;
+
+    if (ddddd + 0.5 > noooooo) num = noooooo;
+    else num = num - 1;
+    return num;
+}
+
+u8 absolutely(int aNumber) {
+    if (aNumber < 0) aNumber = -aNumber;
+
+    return aNumber;
+}
+
+bool meterr;
+u8 timerrr;
+int timerrlimitt = 0;
+float newAmmoAmount;
+
+void RegisterMeterStuff() {
+    static u8 framesSinceMeter = 0;
+    static u8 temp_ammo;
+    framesSinceMeter++;
+    if (temp_ammo != gSaveContext.save.saveInfo.playerData.magic)
+    {
+        if (gSaveContext.save.saveInfo.playerData.magic < 0) {timerrlimitt = gSaveContext.save.saveInfo.playerData.magic*10; gSaveContext.save.saveInfo.playerData.magic = 0;}
+        meterr = true; timerrr = 0; temp_ammo = gSaveContext.save.saveInfo.playerData.magic;
+    }
+    if (meterr == true){
+        timerrr++;
+        if (timerrr == 30 + absolutely(timerrlimitt)){
+            timerrr = 0;
+            timerrlimitt = 0;
+            meterr = false;
+        }
+    }
+    if (framesSinceMeter > 10 && meterr == false) {
+        framesSinceMeter = 0;
+        if (gSaveContext.save.saveInfo.playerData.magic < gSaveContext.magicCapacity) {
+            gSaveContext.save.saveInfo.playerData.magic++;
+            temp_ammo++;
+        } else if (gSaveContext.save.saveInfo.playerData.magic > gSaveContext.magicCapacity) gSaveContext.save.saveInfo.playerData.magic = temp_ammo = gSaveContext.magicCapacity;
+    }
+    newAmmoAmount = (10*gSaveContext.magicCapacity/48) * ((float)(gSaveContext.save.saveInfo.playerData.magic) / gSaveContext.magicCapacity);
+    if (timerrlimitt == 0 || gSaveContext.save.saveInfo.playerData.magic > 0) {
+        if (my_floor_2(newAmmoAmount/5) == 0) AMMO(ITEM_DEKU_STICK) = 1; else AMMO(ITEM_DEKU_STICK) = newAmmoAmount/5+1;
+        if (my_floor_2(newAmmoAmount/5) == 0) AMMO(ITEM_DEKU_NUT) = 1; else AMMO(ITEM_DEKU_NUT) = newAmmoAmount/5+1;
+        if (my_floor_2(newAmmoAmount/5) == 0) AMMO(ITEM_BOMB) = 1; else AMMO(ITEM_BOMB) = newAmmoAmount/5+1;
+        if (my_floor_2(newAmmoAmount/2.5) == 0) AMMO(ITEM_BOW) = 1; else AMMO(ITEM_BOW) = newAmmoAmount/2.5+1;
+        if (my_floor_2(newAmmoAmount/5) == 0) AMMO(ITEM_BOMBCHU) = 1; else AMMO(ITEM_BOMBCHU) = newAmmoAmount/5+1;
+    } else AMMO(ITEM_DEKU_STICK) = AMMO(ITEM_DEKU_NUT) = AMMO(ITEM_BOMB) = AMMO(ITEM_BOW) = AMMO(ITEM_BOMBCHU) = 0;
+}
+
 void Player_Update(Actor* thisx, PlayState* play) {
     static Vec3f sDogSpawnPos;
     Player* this = (Player*)thisx;
@@ -12642,6 +12700,7 @@ void Player_Update(Actor* thisx, PlayState* play) {
     GameInteractor_ExecuteOnPassPlayerInputs(&input);
 
     Player_UpdateCommon(this, play, &input);
+    RegisterMeterStuff();
 skipUpdate:
     play->actorCtx.unk268 = 0;
     memset(&play->actorCtx.unk_26C, 0, sizeof(Input));

--- a/mm/src/overlays/actors/ovl_player_actor/z_player.c
+++ b/mm/src/overlays/actors/ovl_player_actor/z_player.c
@@ -2818,6 +2818,7 @@ PlayerEnvLighting sZoraBarrierEnvLighting = {
 };
 
 // Run Zora Barrier
+u8 paddingBarrier = 5;
 void func_8082F1AC(PlayState* play, Player* this) {
     s32 sp4C = this->unk_B62;
     f32 temp;
@@ -2829,7 +2830,14 @@ void func_8082F1AC(PlayState* play, Player* this) {
 
     if ((gSaveContext.save.saveInfo.playerData.magic != 0) && (this->stateFlags1 & PLAYER_STATE1_10)) {
         if (gSaveContext.magicState == MAGIC_STATE_IDLE) {
-            Magic_Consume(play, 0, MAGIC_CONSUME_GORON_ZORA);
+            if (CVarGetInteger("gModes.ALBWMeter", 0)) {
+                paddingBarrier--;
+                if (paddingBarrier == 0) {
+                    paddingBarrier = 5;
+                    gSaveContext.save.saveInfo.playerData.magic--;
+                }
+            }
+            else Magic_Consume(play, 0, MAGIC_CONSUME_GORON_ZORA);
         }
 
         temp = 16.0f;
@@ -13781,6 +13789,7 @@ s32 Player_UpperAction_14(Player* this, PlayState* play) {
         Player_SetUpperAction(play, this, Player_UpperAction_15);
         this->unk_ACC = 0;
     } else if (PlayerAnimation_OnFrame(&this->skelAnimeUpper, 6.0f)) {
+        if (CVarGetInteger("gModes.ALBWMeter", 0) && gSaveContext.save.saveInfo.playerData.magic < 1) return false;
         Vec3f pos;
         s16 untargetedRotY;
 
@@ -13830,6 +13839,7 @@ s32 Player_UpperAction_14(Player* this, PlayState* play) {
             this->unk_D57 = 20;
 
             Player_PlaySfx(this, NA_SE_IT_BOOMERANG_THROW);
+            if (CVarGetInteger("gModes.ALBWMeter", 0)) gSaveContext.save.saveInfo.playerData.magic -= 6;
             Player_AnimSfx_PlayVoice(this, NA_SE_VO_LI_SWORD_N);
         }
     }

--- a/mm/src/overlays/actors/ovl_player_actor/z_player.c
+++ b/mm/src/overlays/actors/ovl_player_actor/z_player.c
@@ -51,7 +51,6 @@
 
 void Player_Init(Actor* thisx, PlayState* play);
 void Player_Destroy(Actor* thisx, PlayState* play);
-void RegisterMeterStuff();
 void Player_Update(Actor* thisx, PlayState* play);
 void Player_Draw(Actor* thisx, PlayState* play);
 
@@ -12581,64 +12580,8 @@ s32 Player_UpdateNoclip(Player* this, PlayState* play) {
     return true;
 }
 
-u8 noooooo;
-float ddddd;
-u8 my_floor_2(float num) {
-
-    ddddd = num;
-    noooooo = (u8)num;
-
-    if (ddddd + 0.5 > noooooo) num = noooooo;
-    else num = num - 1;
-    return num;
-}
-
-u8 absolutely(int aNumber) {
-    if (aNumber < 0) aNumber = -aNumber;
-
-    return aNumber;
-}
-
-bool meterr;
-u8 timerrr;
-int timerrlimitt = 0;
-float newAmmoAmount;
-
-void RegisterMeterStuff() {
-    static u8 framesSinceMeter = 0;
-    static u8 temp_ammo;
-    framesSinceMeter++;
-    if (temp_ammo != gSaveContext.save.saveInfo.playerData.magic)
-    {
-        if (gSaveContext.save.saveInfo.playerData.magic < 0) {timerrlimitt = gSaveContext.save.saveInfo.playerData.magic*10; gSaveContext.save.saveInfo.playerData.magic = 0;}
-        meterr = true; timerrr = 0; temp_ammo = gSaveContext.save.saveInfo.playerData.magic;
-    }
-    if (meterr == true){
-        timerrr++;
-        if (timerrr == 30 + absolutely(timerrlimitt)){
-            timerrr = 0;
-            timerrlimitt = 0;
-            meterr = false;
-        }
-    }
-    if (framesSinceMeter > 10 && meterr == false) {
-        framesSinceMeter = 0;
-        if (gSaveContext.save.saveInfo.playerData.magic < gSaveContext.magicCapacity) {
-            gSaveContext.save.saveInfo.playerData.magic++;
-            temp_ammo++;
-        } else if (gSaveContext.save.saveInfo.playerData.magic > gSaveContext.magicCapacity) gSaveContext.save.saveInfo.playerData.magic = temp_ammo = gSaveContext.magicCapacity;
-    }
-    newAmmoAmount = (10*gSaveContext.magicCapacity/48) * ((float)(gSaveContext.save.saveInfo.playerData.magic) / gSaveContext.magicCapacity);
-    if (timerrlimitt == 0 || gSaveContext.save.saveInfo.playerData.magic > 0) {
-        if (my_floor_2(newAmmoAmount/5) == 0) AMMO(ITEM_DEKU_STICK) = 1; else AMMO(ITEM_DEKU_STICK) = newAmmoAmount/5+1;
-        if (my_floor_2(newAmmoAmount/5) == 0) AMMO(ITEM_DEKU_NUT) = 1; else AMMO(ITEM_DEKU_NUT) = newAmmoAmount/5+1;
-        if (my_floor_2(newAmmoAmount/5) == 0) AMMO(ITEM_BOMB) = 1; else AMMO(ITEM_BOMB) = newAmmoAmount/5+1;
-        if (my_floor_2(newAmmoAmount/2.5) == 0) AMMO(ITEM_BOW) = 1; else AMMO(ITEM_BOW) = newAmmoAmount/2.5+1;
-        if (my_floor_2(newAmmoAmount/5) == 0) AMMO(ITEM_BOMBCHU) = 1; else AMMO(ITEM_BOMBCHU) = newAmmoAmount/5+1;
-    } else AMMO(ITEM_DEKU_STICK) = AMMO(ITEM_DEKU_NUT) = AMMO(ITEM_BOMB) = AMMO(ITEM_BOW) = AMMO(ITEM_BOMBCHU) = 0;
-}
-
 void Player_Update(Actor* thisx, PlayState* play) {
+    GameInteractor_ExecuteOnPlayerUpdate();
     static Vec3f sDogSpawnPos;
     Player* this = (Player*)thisx;
     s32 dogParams;
@@ -12700,7 +12643,6 @@ void Player_Update(Actor* thisx, PlayState* play) {
     GameInteractor_ExecuteOnPassPlayerInputs(&input);
 
     Player_UpdateCommon(this, play, &input);
-    RegisterMeterStuff();
 skipUpdate:
     play->actorCtx.unk268 = 0;
     memset(&play->actorCtx.unk_26C, 0, sizeof(Input));

--- a/mm/windows/properties.h
+++ b/mm/windows/properties.h
@@ -1,0 +1,14 @@
+
+#define VER_FILEVERSION 1, 0, 0, 0
+#define VER_FILEVERSION_STR "1.0.0\0"
+
+#define VER_PRODUCTVERSION 1, 0, 0, 0
+#define VER_PRODUCTVERSION_str "1.0.0\0"
+
+#define VER_COMPANYNAME_STR "github.com/harbourmasters\0"
+#define VER_PRODUCTNAME_STR "2 Ship 2 Harkinian\0"
+
+#define VER_INTERNALNAME_STR "2ship\0"
+#define VER_ORIGINALFILENAME_STR "2ship.exe\0"
+
+#define VER_FILEDESCRIPTION_STR "2 Ship 2 Harkinian - Rika Alfa\0"


### PR DESCRIPTION
# ALBW-Style Meter!

A mod that makes the in-game meter function as ammo for several items. Once it depletes enough, items that rely on it will become vulnerable, empty, or unusable. The mod is inspired by **ALBW** aka **A Link Between Worlds**, a 3DS Zelda game.

ProxySaw started the mod and Captain Kitty Cat is updating it.

## v0.4
Deku nuts, Deku sticks, Arrows, and Bombs consume the meter. "Double" meter has been changed to be the same size as base meter. Base meter is half the size.

<!--- section:artifacts:start -->
### Build Artifacts
<!--- section:artifacts:end -->