### PR TITLE
ALBW-Style Meter

### DIFF
--- a/mm/2s2h/BenGui/BenMenuBar.cpp
+++ b/mm/2s2h/BenGui/BenMenuBar.cpp
@@ -8,6 +8,8 @@
 #include <unordered_map>
 #include <string>
 #include "2s2h/Enhancements/Enhancements.h"
+#include "2s2h/Enhancements/Graphics/3DItemDrops.h"
+#include "2s2h/Enhancements/Graphics/ALBWStyleMeter.h"
 #include "2s2h/Enhancements/Graphics/MotionBlur.h"
 #include "2s2h/Enhancements/Graphics/PlayAsKafei.h"
 #include "2s2h/DeveloperTools/DeveloperTools.h"
@@ -516,6 +518,8 @@ void DrawEnhancementsMenu() {
                                                  "model and texture on the boot logo start screen" });
             UIWidgets::CVarCheckbox("Bow Reticle", "gEnhancements.Graphics.BowReticle",
                                     { .tooltip = "Gives the bow a reticle when you draw an arrow" });
+            UIWidgets::CVarCheckbox("3D Item Drops", "gEnhancements.Graphics.Item3D",
+                                    { .tooltip = "Makes item drops 3D" });
 
             ImGui::EndMenu();
         }
@@ -539,6 +543,8 @@ void DrawEnhancementsMenu() {
         if (UIWidgets::BeginMenu("Modes")) {
             UIWidgets::CVarCheckbox("Play As Kafei", "gModes.PlayAsKafei",
                                     { .tooltip = "Requires scene reload to take effect." });
+            UIWidgets::CVarCheckbox("ALBW-Style Meter", "gModes.ALBWMeter",
+                                        { .tooltip = "Makes several items utilize the meter." });
             ImGui::EndMenu();
         }
         if (UIWidgets::BeginMenu("Player Movement")) {

--- a/mm/2s2h/DeveloperTools/DeveloperTools.cpp
+++ b/mm/2s2h/DeveloperTools/DeveloperTools.cpp
@@ -56,7 +56,8 @@ void RegisterDebugSaveCreate() {
 
                 gSaveContext.save.saveInfo.inventory.defenseHearts = 20;
                 gSaveContext.save.saveInfo.regionsVisited = (1 << REGION_MAX) - 1;
-                gSaveContext.magicCapacity = MAGIC_DOUBLE_METER;
+                if (CVarGetInteger("gModes.ALBWMeter", 0)) gSaveContext.magicCapacity = 0x30;
+                else gSaveContext.magicCapacity = MAGIC_DOUBLE_METER;
 
                 Inventory_ChangeUpgrade(UPG_WALLET, 2);
                 Inventory_ChangeUpgrade(UPG_BOMB_BAG, 3);

--- a/mm/2s2h/DeveloperTools/SaveEditor.cpp
+++ b/mm/2s2h/DeveloperTools/SaveEditor.cpp
@@ -266,7 +266,8 @@ void DrawGeneralTab() {
 
     ImGui::BeginGroup();
     if (UIWidgets::Button("Max Magic", { .color = UIWidgets::Colors::DarkGreen, .size = UIWidgets::Sizes::Inline })) {
-        gSaveContext.magicCapacity = gSaveContext.save.saveInfo.playerData.magic = MAGIC_DOUBLE_METER;
+        if (CVarGetInteger("gModes.ALBWMeter", 0)) gSaveContext.magicCapacity = gSaveContext.save.saveInfo.playerData.magic = 0x30;
+        else gSaveContext.magicCapacity = gSaveContext.save.saveInfo.playerData.magic = MAGIC_DOUBLE_METER;
         gSaveContext.save.saveInfo.playerData.magicLevel = 2;
         gSaveContext.save.saveInfo.playerData.isMagicAcquired = true;
         gSaveContext.save.saveInfo.playerData.isDoubleMagicAcquired = true;
@@ -284,7 +285,8 @@ void DrawGeneralTab() {
     if (ImGui::SliderScalar("##magicLevelSlider", ImGuiDataType_S8, &gSaveContext.save.saveInfo.playerData.magicLevel,
                             &S8_ZERO, &MAGIC_LEVEL_MAX,
                             MAGIC_LEVEL_NAMES[gSaveContext.save.saveInfo.playerData.magicLevel])) {
-        gSaveContext.magicCapacity = gSaveContext.save.saveInfo.playerData.magicLevel * MAGIC_NORMAL_METER;
+        if (CVarGetInteger("gModes.ALBWMeter", 0)) gSaveContext.magicCapacity = gSaveContext.save.saveInfo.playerData.magicLevel * (0.5 * 0x30);
+        else gSaveContext.magicCapacity = gSaveContext.save.saveInfo.playerData.magicLevel * MAGIC_NORMAL_METER;
         gSaveContext.save.saveInfo.playerData.magic =
             MIN(gSaveContext.save.saveInfo.playerData.magic, gSaveContext.magicCapacity);
         switch (gSaveContext.save.saveInfo.playerData.magicLevel) {

--- a/mm/2s2h/Enhancements/Enhancements.cpp
+++ b/mm/2s2h/Enhancements/Enhancements.cpp
@@ -41,6 +41,8 @@ void InitEnhancements() {
     RegisterCutscenes();
 
     // Modes
+    Register3DItemDrops();
+    RegisterALBWMeter();
     RegisterPlayAsKafei();
 
     // Player Movement

--- a/mm/2s2h/Enhancements/Enhancements.h
+++ b/mm/2s2h/Enhancements/Enhancements.h
@@ -19,6 +19,8 @@
 #include "Restorations/PowerCrouchStab.h"
 #include "Restorations/SideRoll.h"
 #include "Restorations/TatlISG.h"
+#include "Graphics/3DItemDrops.h"
+#include "Graphics/ALBWStyleMeter.h"
 #include "Graphics/PlayAsKafei.h"
 #include "PlayerMovement/ClimbSpeed.h"
 #include "Songs/EnableSunsSong.h"

--- a/mm/2s2h/Enhancements/GameInteractor/GameInteractor.cpp
+++ b/mm/2s2h/Enhancements/GameInteractor/GameInteractor.cpp
@@ -187,6 +187,20 @@ void GameInteractor_ExecuteOnItemGive(u8 item) {
     GameInteractor::Instance->ExecuteHooksForFilter<GameInteractor::OnItemGive>(item);
 }
 
+void GameInteractor_ExecuteOn3DItemDrops(EnItem00* actor, PlayState* play) {
+    GameInteractor::Instance->ExecuteHooks<GameInteractor::On3DItemDrops>(actor, play);
+}
+void GameInteractor_ExecuteOn3DSpinItemdrops(EnItem00* actor, PlayState* play) {
+    GameInteractor::Instance->ExecuteHooks<GameInteractor::On3DSpinItemdrops>(actor, play);
+}
+void GameInteractor_ExecuteOnChangeAmmoHooks(s16 item, s16 ammoChange) {
+    GameInteractor::Instance->ExecuteHooks<GameInteractor::OnChangeAmmo>(item, ammoChange);
+    GameInteractor::Instance->ExecuteHooksForFilter<GameInteractor::OnChangeAmmo>(item, ammoChange);
+}
+void GameInteractor_ExecuteOnPlayerUpdate() {
+    GameInteractor::Instance->ExecuteHooks<GameInteractor::OnPlayerUpdate>();
+}
+
 bool GameInteractor_Should(GIVanillaBehavior flag, bool result, void* opt) {
     GameInteractor::Instance->ExecuteHooks<GameInteractor::ShouldVanillaBehavior>(flag, &result, opt);
     GameInteractor::Instance->ExecuteHooksForID<GameInteractor::ShouldVanillaBehavior>(flag, flag, &result, opt);

--- a/mm/2s2h/Enhancements/GameInteractor/GameInteractor.h
+++ b/mm/2s2h/Enhancements/GameInteractor/GameInteractor.h
@@ -288,6 +288,10 @@ class GameInteractor {
     DEFINE_HOOK(OnItemGive, (u8 item));
 
     DEFINE_HOOK(ShouldVanillaBehavior, (GIVanillaBehavior flag, bool* should, void* optionalArg));
+    DEFINE_HOOK(On3DItemDrops, (EnItem00 * actor, PlayState * play));
+    DEFINE_HOOK(On3DSpinItemdrops, (EnItem00 * actor, PlayState * play));
+    DEFINE_HOOK(OnChangeAmmo, (s16 item, s16 ammoChange));
+    DEFINE_HOOK(OnPlayerUpdate, ());
 };
 
 extern "C" {
@@ -328,6 +332,11 @@ void GameInteractor_ExecuteOnOpenText(u16 textId);
 
 bool GameInteractor_ShouldItemGive(u8 item);
 void GameInteractor_ExecuteOnItemGive(u8 item);
+
+void GameInteractor_ExecuteOn3DItemDrops(EnItem00* actor, PlayState* play);
+void GameInteractor_ExecuteOn3DSpinItemdrops(EnItem00* actor, PlayState* play);
+void GameInteractor_ExecuteOnChangeAmmoHooks(s16 item, s16 ammoChange);
+void GameInteractor_ExecuteOnPlayerUpdate();
 
 bool GameInteractor_Should(GIVanillaBehavior flag, bool result, void* optionalArg);
 #define REGISTER_VB_SHOULD(flag, body)                                                      \

--- a/mm/2s2h/Enhancements/Graphics/3DItemDrops.cpp
+++ b/mm/2s2h/Enhancements/Graphics/3DItemDrops.cpp
@@ -16,3 +16,103 @@ void Register3DItemDrops() {
                 else actor->actor.shape.rot.y = 0;
         }
     );
+    GameInteractor::Instance->RegisterGameHook<GameInteractor::On3DItemDrops>(
+        [](EnItem00* actor, PlayState* play) {
+            if (CVarGetInteger("gEnhancements.Graphics.Item3D", 0)) {
+                f32 mtxScale;
+                bool ALBW = CVarGetInteger("gModes.ALBWMeter", 0);
+                switch (actor->actor.params) {
+                    case ITEM00_RECOVERY_HEART:
+                        mtxScale = 16.0f;
+                        Matrix_Scale(mtxScale, mtxScale, mtxScale, MTXMODE_APPLY);
+                        GetItem_Draw(play, GID_RECOVERY_HEART);
+                        break;
+                    case ITEM00_BOMBS_0:
+                    case ITEM00_BOMBS_A:
+                    case ITEM00_BOMBS_B:
+                        mtxScale = 8.0f;
+                        if (ALBW) {
+                            Matrix_Scale(mtxScale, mtxScale, mtxScale, MTXMODE_APPLY);
+                            GetItem_Draw(play, GID_MAGIC_JAR_BIG);
+                        } else {
+                            Matrix_Scale(mtxScale, mtxScale, mtxScale, MTXMODE_APPLY);
+                            GetItem_Draw(play, GID_BOMB);
+                        }
+                        break;
+                    case ITEM00_ARROWS_10:
+                    case ITEM00_ARROWS_30:
+                        if (ALBW) {
+                            mtxScale = 8.0f;
+                            Matrix_Scale(mtxScale, mtxScale, mtxScale, MTXMODE_APPLY);
+                            GetItem_Draw(play, GID_MAGIC_JAR_SMALL);
+                        } else {
+                            mtxScale = 7.0f;
+                            Matrix_Scale(mtxScale, mtxScale, mtxScale, MTXMODE_APPLY);
+                            GetItem_Draw(play, GID_ARROWS_SMALL);
+                        }
+                        break;
+                    case ITEM00_ARROWS_40:
+                        if (ALBW) {
+                            mtxScale = 8.0f;
+                            Matrix_Scale(mtxScale, mtxScale, mtxScale, MTXMODE_APPLY);
+                            GetItem_Draw(play, GID_MAGIC_JAR_BIG);
+                        } else {
+                            mtxScale = 7.0f;
+                            Matrix_Scale(mtxScale, mtxScale, mtxScale, MTXMODE_APPLY);
+                            GetItem_Draw(play, GID_ARROWS_MEDIUM);
+                        }
+                        break;
+                    case ITEM00_ARROWS_50:
+                        if (ALBW) {
+                            mtxScale = 8.0f;
+                            Matrix_Scale(mtxScale, mtxScale, mtxScale, MTXMODE_APPLY);
+                            GetItem_Draw(play, GID_MAGIC_JAR_BIG);
+                        } else {
+                            mtxScale = 7.0f;
+                            Matrix_Scale(mtxScale, mtxScale, mtxScale, MTXMODE_APPLY);
+                            GetItem_Draw(play, GID_ARROWS_MEDIUM);
+                        }
+                        break;
+                    case ITEM00_DEKU_NUTS_1:
+                    case ITEM00_DEKU_NUTS_10:
+                        if (ALBW) {
+                            mtxScale = 8.0f;
+                            Matrix_Scale(mtxScale, mtxScale, mtxScale, MTXMODE_APPLY);
+                            GetItem_Draw(play, GID_MAGIC_JAR_SMALL);
+                        } else {
+                            mtxScale = 9.0f;
+                            Matrix_Scale(mtxScale, mtxScale, mtxScale, MTXMODE_APPLY);
+                            GetItem_Draw(play, GID_DEKU_NUTS);
+                        }
+                        break;
+                    case ITEM00_DEKU_STICK:
+                        if (ALBW) {
+                            mtxScale = 8.0f;
+                            Matrix_Scale(mtxScale, mtxScale, mtxScale, MTXMODE_APPLY);
+                            GetItem_Draw(play, GID_MAGIC_JAR_SMALL);
+                        } else {
+                            mtxScale = 7.5f;
+                            Matrix_Scale(mtxScale, mtxScale, mtxScale, MTXMODE_APPLY);
+                            GetItem_Draw(play, GID_DEKU_STICK);
+                        }
+                        break;
+                    case ITEM00_MAGIC_JAR_BIG:
+                        mtxScale = 8.0f;
+                        Matrix_Scale(mtxScale, mtxScale, mtxScale, MTXMODE_APPLY);
+                        GetItem_Draw(play, GID_MAGIC_JAR_BIG);
+                        break;
+                    case ITEM00_MAGIC_JAR_SMALL:
+                        mtxScale = 8.0f;
+                        Matrix_Scale(mtxScale, mtxScale, mtxScale, MTXMODE_APPLY);
+                        GetItem_Draw(play, GID_MAGIC_JAR_SMALL);
+                        break;
+                    case ITEM00_SMALL_KEY:
+                        mtxScale = 8.0f;
+                        Matrix_Scale(mtxScale, mtxScale, mtxScale, MTXMODE_APPLY);
+                        GetItem_Draw(play, GID_KEY_SMALL);
+                        break;
+                }
+            }
+        }
+    );
+}

--- a/mm/2s2h/Enhancements/Graphics/3DItemDrops.cpp
+++ b/mm/2s2h/Enhancements/Graphics/3DItemDrops.cpp
@@ -1,0 +1,18 @@
+#include "3DItemDrops.h"
+#include "libultraship/libultraship.h"
+#include "2s2h/Enhancements/GameInteractor/GameInteractor.h"
+
+extern "C" {
+#include "z64.h"
+#include "functions.h"
+extern PlayState* gPlayState;
+}
+
+void Register3DItemDrops() {
+    GameInteractor::Instance->RegisterGameHook<GameInteractor::On3DSpinItemdrops>(
+        [](EnItem00* actor, PlayState* play) {
+                if (CVarGetInteger("gEnhancements.Graphics.Item3D", 0) && ((actor->actor.params >= ITEM00_ARROWS_30 && actor->actor.params < ITEM00_MASK) || actor->actor.params == ITEM00_BOMBS_A || actor->actor.params == ITEM00_ARROWS_10 || actor->actor.params == ITEM00_SMALL_KEY || actor->actor.params == ITEM00_DEKU_NUTS_10 || actor->actor.params == ITEM00_BOMBS_0))
+                    actor->actor.shape.rot.y += 960;
+                else actor->actor.shape.rot.y = 0;
+        }
+    );

--- a/mm/2s2h/Enhancements/Graphics/3DItemDrops.h
+++ b/mm/2s2h/Enhancements/Graphics/3DItemDrops.h
@@ -1,0 +1,6 @@
+#ifndef GRAPHICS_3D_ITEM_DROPS_H
+#define GRAPHICS_3D_ITEM_DROPS_H
+
+void Register3DItemDrops();
+
+#endif // GRAPHICS_3D_ITEM_DROPS_H

--- a/mm/2s2h/Enhancements/Graphics/ALBWStyleMeter.cpp
+++ b/mm/2s2h/Enhancements/Graphics/ALBWStyleMeter.cpp
@@ -1,0 +1,33 @@
+#include "ALBWStyleMeter.h"
+#include "libultraship/libultraship.h"
+#include "2s2h/Enhancements/GameInteractor/GameInteractor.h"
+
+extern "C" {
+#include "z64.h"
+#include "z64save.h"
+#include "functions.h"
+extern PlayState* gPlayState;
+extern SaveContext gSaveContext;
+extern u8 gItemSlots[77];
+}
+
+s8 itemUsage;
+bool meterr;
+s8 timerrr;
+s16 timerrlimitt = 0;
+
+void RegisterALBWMeter() {
+    GameInteractor::Instance->RegisterGameHook<GameInteractor::OnPlayerUpdate>([]() {
+        if (CVarGetInteger("gModes.ALBWMeter", 0)) {
+            static s8 framesSinceMeter = 0;
+            static s8 temp_ammo = gSaveContext.save.saveInfo.playerData.magic;
+            framesSinceMeter++;
+            if (temp_ammo != gSaveContext.save.saveInfo.playerData.magic) {
+                if (gSaveContext.save.saveInfo.playerData.magic < 0) {
+                    timerrlimitt = gSaveContext.save.saveInfo.playerData.magic * 10;
+                    gSaveContext.save.saveInfo.playerData.magic = 0;
+                }
+                meterr = true;
+                timerrr = 0;
+                temp_ammo = gSaveContext.save.saveInfo.playerData.magic;
+            }

--- a/mm/2s2h/Enhancements/Graphics/ALBWStyleMeter.cpp
+++ b/mm/2s2h/Enhancements/Graphics/ALBWStyleMeter.cpp
@@ -31,3 +31,59 @@ void RegisterALBWMeter() {
                 timerrr = 0;
                 temp_ammo = gSaveContext.save.saveInfo.playerData.magic;
             }
+            if (meterr == true) {
+                timerrr++;
+                if (timerrr == 30 + abs(timerrlimitt)) {
+                    timerrr = 0;
+                    timerrlimitt = 0;
+                    meterr = false;
+                }
+            }
+            if (framesSinceMeter > 10 && meterr == false) {
+                framesSinceMeter = 0;
+                if (gSaveContext.save.saveInfo.playerData.magic < gSaveContext.magicCapacity) {
+                    gSaveContext.save.saveInfo.playerData.magic++;
+                    temp_ammo++;
+                } else if (gSaveContext.save.saveInfo.playerData.magic > gSaveContext.magicCapacity)
+                    gSaveContext.save.saveInfo.playerData.magic = temp_ammo = gSaveContext.magicCapacity;
+            }
+            float newAmmoAmount = (10 * gSaveContext.magicCapacity / 48) *
+                            (static_cast<float>(gSaveContext.save.saveInfo.playerData.magic) / gSaveContext.magicCapacity);
+            if (timerrlimitt == 0 || gSaveContext.save.saveInfo.playerData.magic > 0) {
+                if (floor(newAmmoAmount / 5) == 0)
+                    AMMO(ITEM_DEKU_STICK) = 1;
+                else
+                    AMMO(ITEM_DEKU_STICK) = newAmmoAmount / 5 + 1;
+                if (floor(newAmmoAmount / 5) == 0)
+                    AMMO(ITEM_DEKU_NUT) = 1;
+                else
+                    AMMO(ITEM_DEKU_NUT) = newAmmoAmount / 5 + 1;
+                if (floor(newAmmoAmount / 5) == 0)
+                    AMMO(ITEM_BOMB) = 1;
+                else
+                    AMMO(ITEM_BOMB) = newAmmoAmount / 5 + 1;
+                if (floor(newAmmoAmount / 2.5) == 0)
+                    AMMO(ITEM_BOW) = 1;
+                else
+                    AMMO(ITEM_BOW) = newAmmoAmount / 2.5 + 1;
+                if (floor(newAmmoAmount / 5) == 0)
+                    AMMO(ITEM_BOMBCHU) = 1;
+                else
+                    AMMO(ITEM_BOMBCHU) = newAmmoAmount / 5 + 1;
+            } else
+                AMMO(ITEM_DEKU_STICK) = AMMO(ITEM_DEKU_NUT) = AMMO(ITEM_BOMB) = AMMO(ITEM_BOW) = AMMO(ITEM_BOMBCHU) = 0;
+        }
+    });
+    GameInteractor::Instance->RegisterGameHook<GameInteractor::OnChangeAmmo>([](s16 item, s16 ammoChange) {
+        if (CVarGetInteger("gModes.ALBWMeter", 0)) {
+            if (item == ITEM_DEKU_STICK || item == ITEM_DEKU_NUT || item == ITEM_BOW || item == ITEM_BOMB ||
+                item == ITEM_BOMBCHU) {
+                if (item == ITEM_DEKU_NUT || item == ITEM_DEKU_STICK || item == ITEM_BOMB ||item == ITEM_BOMBCHU)
+                    itemUsage = 24;
+                else if (item == ITEM_BOW)
+                    itemUsage = 12;
+                gSaveContext.save.saveInfo.playerData.magic = gSaveContext.save.saveInfo.playerData.magic - itemUsage;
+            }
+        }
+    });
+}

--- a/mm/2s2h/Enhancements/Graphics/ALBWStyleMeter.h
+++ b/mm/2s2h/Enhancements/Graphics/ALBWStyleMeter.h
@@ -1,0 +1,6 @@
+#ifndef ALBW_STYLE_METER_H
+#define ALBW_STYLE_METER_H
+
+void RegisterALBWMeter();
+
+#endif // ALBW_STYLE_METER_H

--- a/mm/src/code/z_en_item00.c
+++ b/mm/src/code/z_en_item00.c
@@ -4,6 +4,7 @@
 #include "objects/object_gi_hearts/object_gi_hearts.h"
 #include "overlays/actors/ovl_En_Elf/z_en_elf.h"
 #include "overlays/actors/ovl_En_Elforg/z_en_elforg.h"
+#include "2s2h/Enhancements/GameInteractor/GameInteractor.h"
 
 #define FLAGS 0x00000000
 
@@ -489,6 +490,7 @@ void func_800A6A40(EnItem00* this, PlayState* play) {
 
 void EnItem00_Update(Actor* thisx, PlayState* play) {
     EnItem00* this = THIS;
+    GameInteractor_ExecuteOn3DSpinItemdrops(this, play);
     s32 pad;
     Player* player = GET_PLAYER(play);
     s32 sp38 = player->stateFlags3 & PLAYER_STATE3_1000;
@@ -573,14 +575,17 @@ void EnItem00_Update(Actor* thisx, PlayState* play) {
             break;
 
         case ITEM00_DEKU_STICK:
+            if (CVarGetInteger("gModes.ALBWMeter", 0)) Item_Give(play, ITEM_MAGIC_JAR_SMALL); else
             getItemId = GI_DEKU_STICKS_1;
             break;
 
         case ITEM00_DEKU_NUTS_1:
+            if (CVarGetInteger("gModes.ALBWMeter", 0)) Item_Give(play, ITEM_MAGIC_JAR_SMALL); else
             getItemId = GI_DEKU_NUTS_1;
             break;
 
         case ITEM00_DEKU_NUTS_10:
+            if (CVarGetInteger("gModes.ALBWMeter", 0)) Item_Give(play, ITEM_MAGIC_JAR_SMALL); else
             getItemId = GI_DEKU_NUTS_10;
             break;
 
@@ -595,22 +600,27 @@ void EnItem00_Update(Actor* thisx, PlayState* play) {
 
         case ITEM00_BOMBS_A:
         case ITEM00_BOMBS_B:
+            if (CVarGetInteger("gModes.ALBWMeter", 0)) Item_Give(play, ITEM_MAGIC_JAR_BIG); else
             Item_Give(play, ITEM_BOMBS_5);
             break;
 
         case ITEM00_ARROWS_10:
+            if (CVarGetInteger("gModes.ALBWMeter", 0)) Item_Give(play, ITEM_MAGIC_JAR_SMALL); else
             Item_Give(play, ITEM_ARROWS_10);
             break;
 
         case ITEM00_ARROWS_30:
+            if (CVarGetInteger("gModes.ALBWMeter", 0)) Item_Give(play, ITEM_MAGIC_JAR_SMALL); else
             Item_Give(play, ITEM_ARROWS_30);
             break;
 
         case ITEM00_ARROWS_40:
+            if (CVarGetInteger("gModes.ALBWMeter", 0)) Item_Give(play, ITEM_MAGIC_JAR_BIG); else
             Item_Give(play, ITEM_ARROWS_40);
             break;
 
         case ITEM00_ARROWS_50:
+            if (CVarGetInteger("gModes.ALBWMeter", 0)) Item_Give(play, ITEM_MAGIC_JAR_BIG); else
             Item_Give(play, ITEM_ARROWS_50);
             break;
 
@@ -700,6 +710,21 @@ void EnItem00_Update(Actor* thisx, PlayState* play) {
     this->actionFunc = func_800A6A40;
 }
 
+TexturePtr sItemDropTextures[] = {
+    gDropRecoveryHeartTex, // Heart (Not used)
+    gDropBombTex,          // Bombs (A), Bombs (0)
+    gDropArrows1Tex,       // Arrows (10)
+    gDropArrows2Tex,       // Arrows (30)
+    gDropArrows3Tex,       // Arrows (40), Arrows (50)
+    gDropBombTex,          // Bombs (B)
+    gDropDekuNutTex,       // Nuts (1), Nuts (10)
+    gDropDekuStickTex,     // Sticks (1)
+    gDropMagicLargeTex,    // Magic (Large)
+    gDropMagicSmallTex,    // Magic (Small)
+    NULL,
+    gDropKeySmallTex // Small Key
+};
+
 void EnItem00_Draw(Actor* thisx, PlayState* play) {
     s32 pad;
     EnItem00* this = THIS;
@@ -752,6 +777,9 @@ void EnItem00_Draw(Actor* thisx, PlayState* play) {
             case ITEM00_SMALL_KEY:
             case ITEM00_DEKU_NUTS_10:
             case ITEM00_BOMBS_0:
+                GameInteractor_ExecuteOn3DItemDrops(this, play);
+                if (CVarGetInteger("gModes.ALBWMeter", 0)) {sItemDropTextures[1] = gDropMagicLargeTex; sItemDropTextures[2] = gDropMagicSmallTex; sItemDropTextures[3] = gDropMagicSmallTex; sItemDropTextures[4] = gDropMagicLargeTex; sItemDropTextures[5] = gDropMagicLargeTex; sItemDropTextures[6] = gDropMagicSmallTex; sItemDropTextures[7] = gDropMagicSmallTex;}
+                else {sItemDropTextures[1] = gDropBombTex; sItemDropTextures[2] = gDropArrows1Tex; sItemDropTextures[3] = gDropArrows2Tex; sItemDropTextures[4] = gDropArrows3Tex; sItemDropTextures[5] = gDropBombTex; sItemDropTextures[6] = gDropDekuNutTex; sItemDropTextures[7] = gDropDekuStickTex;}
                 EnItem00_DrawSprite(this, play);
                 break;
 
@@ -805,22 +833,8 @@ void EnItem00_DrawRupee(EnItem00* this, PlayState* play) {
     CLOSE_DISPS(play->state.gfxCtx);
 }
 
-TexturePtr sItemDropTextures[] = {
-    gDropRecoveryHeartTex, // Heart (Not used)
-    gDropBombTex,          // Bombs (A), Bombs (0)
-    gDropArrows1Tex,       // Arrows (10)
-    gDropArrows2Tex,       // Arrows (30)
-    gDropArrows3Tex,       // Arrows (40), Arrows (50)
-    gDropBombTex,          // Bombs (B)
-    gDropDekuNutTex,       // Nuts (1), Nuts (10)
-    gDropDekuStickTex,     // Sticks (1)
-    gDropMagicLargeTex,    // Magic (Large)
-    gDropMagicSmallTex,    // Magic (Small)
-    NULL,
-    gDropKeySmallTex // Small Key
-};
-
 void EnItem00_DrawSprite(EnItem00* this, PlayState* play) {
+    if (CVarGetInteger("gEnhancements.Graphics.Item3D", 0) == 0) {
     s32 texIndex = this->actor.params - 3;
 
     OPEN_DISPS(play->state.gfxCtx);
@@ -847,6 +861,7 @@ void EnItem00_DrawSprite(EnItem00* this, PlayState* play) {
     gSPDisplayList(POLY_OPA_DISP++, gItemDropDL);
 
     CLOSE_DISPS(play->state.gfxCtx);
+    }
 }
 
 void EnItem00_DrawHeartContainer(EnItem00* this, PlayState* play) {

--- a/mm/src/code/z_parameter.c
+++ b/mm/src/code/z_parameter.c
@@ -2907,6 +2907,14 @@ void Interface_UpdateButtonsPart2(PlayState* play) {
                             }
                         }
                     }
+                    if (CVarGetInteger("gModes.ALBWMeter", 0) && gSaveContext.save.saveInfo.playerData.magic < 1) {
+                        if (GET_CUR_FORM_BTN_ITEM(i) == ITEM_HOOKSHOT) {
+                            if ((gSaveContext.buttonStatus[i] == BTN_ENABLED)) {
+                                restoreHudVisibility = true;
+                                gSaveContext.buttonStatus[i] = BTN_DISABLED;
+                            }
+                        }
+                    }
                 }
             }
             // #region 2S2H [Dpad]
@@ -3051,6 +3059,14 @@ void Interface_UpdateButtonsPart2(PlayState* play) {
                             if ((gSaveContext.shipSaveContext.dpad.status[j] == BTN_DISABLED)) {
                                 restoreHudVisibility = true;
                                 gSaveContext.shipSaveContext.dpad.status[j] = BTN_ENABLED;
+                            }
+                        }
+                    }
+                    if (CVarGetInteger("gModes.ALBWMeter", 0) && gSaveContext.save.saveInfo.playerData.magic < 1) {
+                        if (GET_CUR_FORM_BTN_ITEM(j) == ITEM_HOOKSHOT) {
+                            if ((gSaveContext.shipSaveContext.dpad.status[j] == BTN_ENABLED)) {
+                                restoreHudVisibility = true;
+                                gSaveContext.shipSaveContext.dpad.status[j] = BTN_DISABLED;
                             }
                         }
                     }
@@ -4528,6 +4544,7 @@ void Rupees_ChangeBy(s16 rupeeChange) {
 }
 
 void Inventory_ChangeAmmo(s16 item, s16 ammoChange) {
+    GameInteractor_ExecuteOnChangeAmmoHooks(item, ammoChange);
     if (item == ITEM_DEKU_STICK) {
         AMMO(ITEM_DEKU_STICK) += ammoChange;
 
@@ -4823,7 +4840,15 @@ void Magic_Update(PlayState* play) {
         case MAGIC_STATE_STEP_CAPACITY:
             // Step magicCapacity to the capacity determined by magicLevel
             // This changes the width of the magic meter drawn
-            magicCapacityTarget = gSaveContext.save.saveInfo.playerData.magicLevel * MAGIC_NORMAL_METER;
+            if (CVarGetInteger("gModes.ALBWMeter", 0)) {
+                if (gSaveContext.save.saveInfo.playerData.magicLevel == 2)
+                    magicCapacityTarget = MAGIC_NORMAL_METER;
+                else if (gSaveContext.save.saveInfo.playerData.magicLevel == 1)
+                    magicCapacityTarget = 0.5 * MAGIC_NORMAL_METER;
+                else
+                    magicCapacityTarget = 0;
+            }
+            else magicCapacityTarget = gSaveContext.save.saveInfo.playerData.magicLevel * MAGIC_NORMAL_METER;
             if (gSaveContext.magicCapacity != magicCapacityTarget) {
                 if (gSaveContext.magicCapacity < magicCapacityTarget) {
                     gSaveContext.magicCapacity += 0x10;
@@ -4917,7 +4942,8 @@ void Magic_Update(PlayState* play) {
                     break;
                 }
 
-                interfaceCtx->magicConsumptionTimer--;
+                if (CVarGetInteger("gModes.ALBWMeter", 0)) interfaceCtx->magicConsumptionTimer -= 10;
+                else interfaceCtx->magicConsumptionTimer--;
                 if (interfaceCtx->magicConsumptionTimer == 0) {
                     if (!CHECK_WEEKEVENTREG(WEEKEVENTREG_DRANK_CHATEAU_ROMANI)) {
                         gSaveContext.save.saveInfo.playerData.magic--;
@@ -5068,7 +5094,8 @@ void Magic_DrawMeter(PlayState* play) {
                 gDPSetPrimColor(OVERLAY_DISP++, 0, 0, 0, 0, 200, interfaceCtx->magicAlpha);
             } else {
                 // Green magic (default)
-                gDPSetPrimColor(OVERLAY_DISP++, 0, 0, 0, 200, 0, interfaceCtx->magicAlpha);
+                if (CVarGetInteger("gModes.ALBWMeter", 0)) gDPSetPrimColor(OVERLAY_DISP++, 0, 0, 203, 82, 255, interfaceCtx->magicAlpha);
+                else gDPSetPrimColor(OVERLAY_DISP++, 0, 0, 0, 200, 0, interfaceCtx->magicAlpha);
             }
 
             // #region 2S2H [Cosmetic] Hud Editor
@@ -5108,7 +5135,8 @@ void Magic_DrawMeter(PlayState* play) {
                 gDPSetPrimColor(OVERLAY_DISP++, 0, 0, 0, 0, 200, interfaceCtx->magicAlpha);
             } else {
                 // Green magic (default)
-                gDPSetPrimColor(OVERLAY_DISP++, 0, 0, 0, 200, 0, interfaceCtx->magicAlpha);
+                if (CVarGetInteger("gModes.ALBWMeter", 0)) gDPSetPrimColor(OVERLAY_DISP++, 0, 0, 203, 82, 255, interfaceCtx->magicAlpha);
+                else gDPSetPrimColor(OVERLAY_DISP++, 0, 0, 0, 200, 0, interfaceCtx->magicAlpha);
             }
 
             gDPLoadTextureBlock_4b(OVERLAY_DISP++, gMagicMeterFillTex, G_IM_FMT_I, 16, 16, 0, G_TX_NOMIRROR | G_TX_WRAP,
@@ -9107,7 +9135,8 @@ void Interface_Update(PlayState* play) {
                 gSaveContext.save.saveInfo.playerData.isMagicAcquired = true;
             }
             gSaveContext.save.saveInfo.playerData.isDoubleMagicAcquired = true;
-            gSaveContext.save.saveInfo.playerData.magic = MAGIC_DOUBLE_METER;
+            if (CVarGetInteger("gModes.ALBWMeter", 0)) gSaveContext.save.saveInfo.playerData.magic = 0x30;
+            else gSaveContext.save.saveInfo.playerData.magic = MAGIC_DOUBLE_METER;
             gSaveContext.save.saveInfo.playerData.magicLevel = 0;
             R_MAGIC_DBG_SET_UPGRADE = MAGIC_DBG_SET_UPGRADE_NO_ACTION;
         } else if (R_MAGIC_DBG_SET_UPGRADE == MAGIC_DBG_SET_UPGRADE_NORMAL_METER) {
@@ -9116,7 +9145,8 @@ void Interface_Update(PlayState* play) {
                 gSaveContext.save.saveInfo.playerData.isMagicAcquired = true;
             }
             gSaveContext.save.saveInfo.playerData.isDoubleMagicAcquired = false;
-            gSaveContext.save.saveInfo.playerData.magic = MAGIC_NORMAL_METER;
+            if (CVarGetInteger("gModes.ALBWMeter", 0)) gSaveContext.save.saveInfo.playerData.magic = MAGIC_NORMAL_METER * 0.5;
+            else gSaveContext.save.saveInfo.playerData.magic = MAGIC_NORMAL_METER;
             gSaveContext.save.saveInfo.playerData.magicLevel = 0;
             R_MAGIC_DBG_SET_UPGRADE = MAGIC_DBG_SET_UPGRADE_NO_ACTION;
         }

--- a/mm/src/overlays/actors/ovl_Arms_Hook/z_arms_hook.c
+++ b/mm/src/overlays/actors/ovl_Arms_Hook/z_arms_hook.c
@@ -126,6 +126,8 @@ void ArmsHook_AttachHookToActor(ArmsHook* this, Actor* actor) {
     this->grabbed = actor;
     Math_Vec3f_Diff(&actor->world.pos, &this->actor.world.pos, &this->unk1FC);
 }
+bool hook1Frame = false;
+bool hookshotMoment = false;
 
 void ArmsHook_Shoot(ArmsHook* this, PlayState* play) {
     Player* player = GET_PLAYER(play);
@@ -135,7 +137,7 @@ void ArmsHook_Shoot(ArmsHook* this, PlayState* play) {
         Actor_Kill(&this->actor);
         return;
     }
-
+    if (CVarGetInteger("gModes.ALBWMeter", 0)) {if (hook1Frame != true) {hook1Frame = true; gSaveContext.save.saveInfo.playerData.magic -= 6;} hookshotMoment = true;}
     Actor_PlaySfx_FlaggedCentered1(&player->actor, NA_SE_IT_HOOKSHOT_CHAIN - SFX_FLAG);
     ArmsHook_CheckForCancel(this);
 
@@ -281,6 +283,11 @@ void ArmsHook_Update(Actor* thisx, PlayState* play) {
 
     this->actionFunc(this, play);
     this->unk1EC = this->unk1E0;
+
+    if (CVarGetInteger("gModes.ALBWMeter", 0)) {
+        if (hook1Frame && !hookshotMoment) hook1Frame = false;
+        hookshotMoment = false;
+    }
 }
 
 Vec3f D_808C1C10 = { 0.0f, 0.0f, 0.0f };

--- a/mm/src/overlays/actors/ovl_player_actor/z_player.c
+++ b/mm/src/overlays/actors/ovl_player_actor/z_player.c
@@ -2818,6 +2818,7 @@ PlayerEnvLighting sZoraBarrierEnvLighting = {
 };
 
 // Run Zora Barrier
+u8 paddingBarrier = 5;
 void func_8082F1AC(PlayState* play, Player* this) {
     s32 sp4C = this->unk_B62;
     f32 temp;
@@ -2829,7 +2830,14 @@ void func_8082F1AC(PlayState* play, Player* this) {
 
     if ((gSaveContext.save.saveInfo.playerData.magic != 0) && (this->stateFlags1 & PLAYER_STATE1_10)) {
         if (gSaveContext.magicState == MAGIC_STATE_IDLE) {
-            Magic_Consume(play, 0, MAGIC_CONSUME_GORON_ZORA);
+            if (CVarGetInteger("gModes.ALBWMeter", 0)) {
+                paddingBarrier--;
+                if (paddingBarrier == 0) {
+                    paddingBarrier = 5;
+                    gSaveContext.save.saveInfo.playerData.magic--;
+                }
+            }
+            else Magic_Consume(play, 0, MAGIC_CONSUME_GORON_ZORA);
         }
 
         temp = 16.0f;
@@ -12581,6 +12589,7 @@ s32 Player_UpdateNoclip(Player* this, PlayState* play) {
 }
 
 void Player_Update(Actor* thisx, PlayState* play) {
+    GameInteractor_ExecuteOnPlayerUpdate();
     static Vec3f sDogSpawnPos;
     Player* this = (Player*)thisx;
     s32 dogParams;
@@ -13780,6 +13789,7 @@ s32 Player_UpperAction_14(Player* this, PlayState* play) {
         Player_SetUpperAction(play, this, Player_UpperAction_15);
         this->unk_ACC = 0;
     } else if (PlayerAnimation_OnFrame(&this->skelAnimeUpper, 6.0f)) {
+        if (CVarGetInteger("gModes.ALBWMeter", 0) && gSaveContext.save.saveInfo.playerData.magic < 1) return false;
         Vec3f pos;
         s16 untargetedRotY;
 
@@ -13829,6 +13839,7 @@ s32 Player_UpperAction_14(Player* this, PlayState* play) {
             this->unk_D57 = 20;
 
             Player_PlaySfx(this, NA_SE_IT_BOOMERANG_THROW);
+            if (CVarGetInteger("gModes.ALBWMeter", 0)) gSaveContext.save.saveInfo.playerData.magic -= 6;
             Player_AnimSfx_PlayVoice(this, NA_SE_VO_LI_SWORD_N);
         }
     }


### PR DESCRIPTION
To use the mod, press `F1` and navigate to `Enhancements->Modes->ALBW-Style Meter`
# ALBW-Style Meter
A mod that makes the in-game meter function as ammo for several items. Once it depletes, items that consume it will become vulnerable, empty, or unusable. The mod is inspired by A Link Between Worlds, a 3DS Zelda game.

ProxySaw Started the mod (in OoT) and Captain Kitty Cat is updating it.

## v0.8.1 Update
### New/Adjustments
* Support for 3D item drops. Enable by navigating to `Enhancements->Graphics->3D Item Drops`.
* Linux Support.
* Mac Support
* Uses v1.0.1
* Minor item drop fix when disabling the mod.

<!--- section:artifacts:start -->
### Build Artifacts
  - [2ship-linux.zip](https://nightly.link/Captainkittyca2/MM-PC/actions/artifacts/1930274574.zip)
  - [2ship-windows.zip](https://nightly.link/Captainkittyca2/MM-PC/actions/artifacts/1930295275.zip)
<!--- section:artifacts:end -->